### PR TITLE
i17: Update to work with new dust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     packages:
       - libnode-dev
 r_github_packages:
-  - mrc-ide/dust@i27-float
+  - mrc-ide/dust
 r_packages:
   - covr
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
     packages:
       - libnode-dev
 r_github_packages:
-  - mrc-ide/dde
-  - mrc-ide/dust
+  - mrc-ide/dust@i27-float
 r_packages:
   - covr
 after_success:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Language: en-GB
 URL: https://github.com/mrc-ide/mcstate
 BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
-    dust,
+    dust (>= 0.0.2),
     odin,
     coda,
     mvtnorm,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ URL: https://github.com/mrc-ide/mcstate
 BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     dust (>= 0.0.2),
-    odin,
     coda,
     mvtnorm,
     viridis

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -89,9 +89,8 @@ particle_filter <- R6::R6Class(
     ##' \code{step_start} and \code{step_end}.  Additional columns are
     ##' used for comparison with the simulation.
     ##'
-    ##' @param model A stochastic model to use.  Must be an
-    ##' \code{odin_generator} object (i.e., something that can be used to
-    ##' create an \code{odin_model}).
+    ##' @param model A stochastic model to use.  Must be a
+    ##' \code{dust_generator} object.
     ##'
     ##' @param compare A comparison function.  Must take arguments
     ##' \code{state}, \code{output}, \code{data} and \code{pars} as arguments

--- a/inst/example/sir/dust_sir.cpp
+++ b/inst/example/sir/dust_sir.cpp
@@ -2,6 +2,8 @@
 
 class sir {
 public:
+  typedef int int_t;
+  typedef double real_t;
   struct init_t {
     double beta;
     double dt;

--- a/inst/example/sir/dust_sir.cpp
+++ b/inst/example/sir/dust_sir.cpp
@@ -30,7 +30,8 @@ public:
     return ret;
   }
 
-  void update(size_t step, const std::vector<double> state, dust::RNG& rng,
+  void update(size_t step, const std::vector<double> state,
+              dust::RNG<double, int>& rng,
               std::vector<double>& state_next) {
     double S = state[0];
     double I = state[1];

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -100,9 +100,8 @@ Must be a \code{\link{data.frame}} with at least columns
 \code{step_start} and \code{step_end}.  Additional columns are
 used for comparison with the simulation.}
 
-\item{\code{model}}{A stochastic model to use.  Must be an
-\code{odin_generator} object (i.e., something that can be used to
-create an \code{odin_model}).}
+\item{\code{model}}{A stochastic model to use.  Must be a
+\code{dust_generator} object.}
 
 \item{\code{compare}}{A comparison function.  Must take arguments
 \code{state}, \code{output}, \code{data} and \code{pars} as arguments


### PR DESCRIPTION
This PR adds the type declarations to the model required to work with dust >= 0.0.2

Requires mrc-ide/dust#28
Fixes #17 
Fixes #16 