### PR TITLE
i21: rationalise arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ vignettes: vignettes/traduire.Rmd
 	mkdir -p inst/doc
 	cp vignettes/*.html vignettes/*.Rmd inst/doc
 
-.PHONY: all test document install vignettes
+.PHONY: all test document install vignettes pkgdown

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -18,8 +18,6 @@
 ##'   this will be full parameter sets sampled evenly from the chains.
 ##'   Integer. This will determine how many trajectories are returned.
 ##'
-##' @param n_particles Number of particles. Positive Integer. Default = 100
-##'
 ##' @param forecast_steps Number of time steps being forecast. Default = 0
 ##'
 ##' @param burn_in Amount of burn in to remove (if an \code{mcstate_pmcmc_list})
@@ -35,11 +33,9 @@
 forecast <- function(x, ...,
                      filter,
                      n_sample_pars = 10,
-                     n_particles = 100,
                      forecast_steps = 0,
                      burn_in = 0) {
   assert_integer(n_sample_pars)
-  assert_integer(n_particles)
   assert_integer(forecast_steps)
   UseMethod("forecast", x)
 }
@@ -50,7 +46,6 @@ forecast <- function(x, ...,
 forecast.mcstate_scan <- function(x, ...,
                                   filter,
                                   n_sample_pars = 10,
-                                  n_particles = 100,
                                   forecast_steps = 0) {
 
   # sample proportional to probability
@@ -61,8 +56,7 @@ forecast.mcstate_scan <- function(x, ...,
   pairs <- x$vars$expanded[sample_idx, ]
 
   traces <- lapply(split_df_rows(pairs), run_and_forecast,
-                   filter, x$vars$index, n_particles,
-                   forecast_steps)
+                   filter, x$vars$index, forecast_steps)
 
   # combine and return
   res <- list("trajectories" = traces,
@@ -79,7 +73,6 @@ forecast.mcstate_scan <- function(x, ...,
 forecast.mcstate_pmcmc_list <- function(x, ...,
                                         filter,
                                         n_sample_pars = 10,
-                                        n_particles = 100,
                                         forecast_steps = 0,
                                         burn_in = 1) {
 
@@ -94,8 +87,7 @@ forecast.mcstate_pmcmc_list <- function(x, ...,
                                   replace = FALSE), par_names]
 
   traces <- lapply(split_df_rows(param_grid), run_and_forecast,
-                   filter, x$vars$index, n_particles,
-                   forecast_steps)
+                   filter, x$vars$index, forecast_steps)
 
   # combine and return
   res <- list("trajectories" = traces,
@@ -106,9 +98,8 @@ forecast.mcstate_pmcmc_list <- function(x, ...,
 
 }
 
-run_and_forecast <- function(model_params, filter, index, n_particles,
-                             forecast_steps) {
-  filter$run2(n_particles, save_history = TRUE, index, model_params)
+run_and_forecast <- function(model_params, filter, index, forecast_steps) {
+  filter$run2(save_history = TRUE, index, model_params)
   if (forecast_steps > 0) {
     forward_steps <- seq.int(0, forecast_steps)
     trajectories <- filter$predict(forward_steps, append = TRUE)

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -99,7 +99,7 @@ forecast.mcstate_pmcmc_list <- function(x, ...,
 }
 
 run_and_forecast <- function(model_params, filter, index, forecast_steps) {
-  filter$run2(save_history = TRUE, index, model_params)
+  filter$run2(model_params, index, save_history = TRUE)
   if (forecast_steps > 0) {
     forward_steps <- seq.int(0, forecast_steps)
     trajectories <- filter$predict(forward_steps, append = TRUE)

--- a/R/grid_search.R
+++ b/R/grid_search.R
@@ -20,7 +20,7 @@ grid_search <- function(range, filter, tolerance = 0.01) {
   flat_log_ll <- vnapply(seq_len(nrow(vars$expanded)), function(i) {
     pars <- vars$expanded[i, ]
     names(pars) <- colnames(vars$expanded)
-    filter$run2(save_history = FALSE, index = vars$index, pars = pars)
+    filter$run2(pars, vars$index)
   })
 
   mat_log_ll <- matrix(

--- a/R/grid_search.R
+++ b/R/grid_search.R
@@ -7,26 +7,21 @@
 ##'
 ##' @param filter A \code{particle_filter} object to run
 ##'
-##' @param n_particles Number of particles. Positive Integer. Default = 100
-##'
 ##' @param tolerance Check around edges of the probability matrix
-##'
-##' @param run_params Passed to \code{particle_filter$run}
 ##'
 ##' @return List of beta and start date grid values, and
 ##'   normalised probabilities at each point
 ##'
 ##' @export
-grid_search <- function(range, filter, n_particles, tolerance=1E-2,
-                        run_params = NULL) {
+grid_search <- function(range, filter, tolerance = 0.01) {
   vars <- grid_search_validate_range(range)
 
   # Run the search, which returns a log-likelihood
   flat_log_ll <- vnapply(seq_len(nrow(vars$expanded)), function(i) {
     pars <- vars$expanded[i, ]
     names(pars) <- colnames(vars$expanded)
-    filter$run2(n_particles, save_history = FALSE, index = vars$index,
-                pars = pars, run_params = run_params)})
+    filter$run2(save_history = FALSE, index = vars$index, pars = pars)
+  })
 
   mat_log_ll <- matrix(
     flat_log_ll,

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -203,7 +203,6 @@ particle_filter <- R6::R6Class(
                    pars_initial = NULL) {
       compare <- private$compare
       steps <- private$steps
-      run_params <- validate_dust_params(run_params)
 
       if (is.null(private$last_model)) {
         model <- self$model$new(data = pars_model, step = steps[[1L]],

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -303,15 +303,21 @@ particle_filter <- R6::R6Class(
       log_likelihood
     },
 
-    ##' Run the particle filter, modifying parameters
-    ##'
-    ##' @param save_history Logical, indicating if the history of all
-    ##' particles should be saved
-    ##'
-    ##' @param index A parameter index
+    ##' Run the particle filter, allocating a vector of parameters across
+    ##' the different tuneable components (model, initial and compare).
+    ##' This is a wrapper around the \code{$run()} method, used by
+    ##' \code{\link{pmcmc}} and \code{\link{grid_search}} though it can
+    ##' be used directly (the name may change in future).
     ##'
     ##' @param pars A list of parameters
-    run2 = function(save_history = FALSE, index, pars) {
+    ##'
+    ##' @param index A parameter index; this must be a list with elements
+    ##' \code{pars_model}, \code{pars_compare} and \code{pars_initial},
+    ##' indicating the argument of \code{$run()} they apply to.
+    ##'
+    ##' @param save_history Logical, indicating if the history of all
+    ##' particles should be saved.
+    run2 = function(pars, index, save_history = FALSE) {
       pars_model <- pars_compare <- pars_initial <- NULL
       if (length(index$pars_model) > 0) {
         pars_model <- pars[index$pars_model]

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -42,9 +42,9 @@
 ##'   dpois(x = incidence_observed, lambda = lambda, log = TRUE)
 ##' }
 ##'
-##' # Construct the particle_filter object:
-##' p <- particle_filter$new(data, gen, compare)
-##' p$run(list(), 100, TRUE)
+##' # Construct the particle_filter object with 100 particles
+##' p <- particle_filter$new(data, gen, 100, compare)
+##' p$run(list(), save_history = TRUE)
 ##'
 ##' # Our simulated trajectories, with the "real" data superimposed
 ##' matplot(data_raw$day, t(p$history[1, , -1]), type = "l",

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -44,7 +44,7 @@
 ##'
 ##' # Construct the particle_filter object with 100 particles
 ##' p <- particle_filter$new(data, gen, 100, compare)
-##' p$run(list(), save_history = TRUE)
+##' p$run(save_history = TRUE)
 ##'
 ##' # Our simulated trajectories, with the "real" data superimposed
 ##' matplot(data_raw$day, t(p$history[1, , -1]), type = "l",
@@ -200,10 +200,13 @@ particle_filter <- R6::R6Class(
     ##'
     ##' @return A single numeric value representing the log-likelihood
     ##' (\code{-Inf} if the model is impossible)
-    run = function(pars_model, save_history = FALSE, pars_compare = NULL,
-                   pars_initial = NULL) {
+    run = function(pars_model = NULL, pars_compare = NULL, pars_initial = NULL,
+                   save_history = FALSE) {
       compare <- private$compare
       steps <- private$steps
+
+      ## Needed by the cpp11 interface
+      pars_model <- as.list(pars_model)
 
       if (is.null(private$last_model)) {
         model <- self$model$new(data = pars_model, step = steps[[1L]],
@@ -322,8 +325,7 @@ particle_filter <- R6::R6Class(
         pars_initial <- pars[index$pars_initial]
       }
 
-      self$run(pars_model, save_history, pars_compare,
-               pars_initial = pars_initial)
+      self$run(pars_model, pars_compare, pars_initial, save_history)
     },
 
     ##' Create predicted trajectories, based on the final point of a

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -174,9 +174,10 @@ particle_filter <- R6::R6Class(
       private$index <- index
       private$initial <- initial
 
-      private$n_particles <- n_particles
-      private$n_threads <- n_threads
-      private$seed <- seed
+      private$n_particles <- assert_scalar_positive_integer(n_particles)
+      private$n_threads <- assert_scalar_positive_integer(n_threads)
+      private$seed <- assert_scalar_positive_integer(seed)
+
       lockBinding("model", self)
     },
 
@@ -443,28 +444,6 @@ particle_steps <- function(steps, step_start) {
     steps[1, 1] <- max(step_start)
   }
   steps
-}
-
-
-validate_dust_params <- function(run_params) {
-  if (is.null(run_params)) {
-    run_params <- list(n_threads = 1L, seed = 1L)
-  } else {
-    run_params[["n_threads"]] <-
-      validate_dust_params_size(run_params[["n_threads"]])
-    run_params[["seed"]] <-
-      validate_dust_params_size(run_params[["seed"]])
-  }
-  run_params
-}
-
-
-validate_dust_params_size <- function(x) {
-  if (is.null(x) || x < 1) {
-    1L
-  } else {
-    as.integer(x)
-  }
 }
 
 

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -15,13 +15,9 @@
 ##'
 ##' @param filter A particle filter to sample
 ##'
-##' @param n_particles Number of particles
-##'
 ##' @param n_mcmc Number of MCMC steps
 ##'
 ##' @param proposal_kernel named matrix of proposal covariance for parameters
-##'
-##' @param run_params List of parameters for \code{particle_filter$run}
 ##'
 ##' @param output_proposals Logical indicating whether proposed parameter
 ##' jumps should be output along with results
@@ -48,10 +44,8 @@
 pmcmc <- function(mcmc_range,
                   lprior_funcs,
                   filter,
-                  n_particles,
                   n_mcmc,
                   proposal_kernel,
-                  run_params = NULL,
                   output_proposals = FALSE,
                   n_chains = 1) {
   vars <- mcmc_validate_range(mcmc_range)
@@ -84,9 +78,7 @@ pmcmc <- function(mcmc_range,
                      vars,
                      lprior_funcs,
                      filter,
-                     n_particles,
                      proposal_kernel,
-                     run_params = run_params,
                      output_proposals = output_proposals)
 
   if (n_chains > 1) {
@@ -122,9 +114,7 @@ run_mcmc_chain <- function(n_mcmc,
                            vars,
                            lprior_funcs,
                            filter,
-                           n_particles,
                            proposal_kernel,
-                           run_params = NULL,
                            output_proposals = FALSE) {
   #
   # Set initial state
@@ -136,11 +126,9 @@ run_mcmc_chain <- function(n_mcmc,
   curr_lprior <- calc_lprior(curr_pars, lprior_funcs)
 
   # run particle filter on initial parameters
-  curr_ll <- filter$run2(n_particles,
-                         save_history = FALSE,
+  curr_ll <- filter$run2(save_history = FALSE,
                          index = vars$index,
-                         pars = as.list(curr_pars),
-                         run_params = run_params)
+                         pars = as.list(curr_pars))
   curr_lpost <- curr_lprior + curr_ll
 
   # checks on log_prior and log_likelihood functions
@@ -190,11 +178,9 @@ run_mcmc_chain <- function(n_mcmc,
 
     ## calculate proposed prior / lhood / posterior
     prop_lprior <- calc_lprior(prop_pars, lprior_funcs)
-    prop_ll <- filter$run2(n_particles,
-                           save_history = FALSE,
+    prop_ll <- filter$run2(save_history = FALSE,
                            index = vars$index,
-                           pars = as.list(prop_pars),
-                           run_params = run_params)
+                           pars = as.list(prop_pars))
     prop_lpost <- prop_lprior + prop_ll
 
     # calculate probability of acceptance

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -126,9 +126,7 @@ run_mcmc_chain <- function(n_mcmc,
   curr_lprior <- calc_lprior(curr_pars, lprior_funcs)
 
   # run particle filter on initial parameters
-  curr_ll <- filter$run2(save_history = FALSE,
-                         index = vars$index,
-                         pars = as.list(curr_pars))
+  curr_ll <- filter$run2(as.list(curr_pars), vars$index)
   curr_lpost <- curr_lprior + curr_ll
 
   # checks on log_prior and log_likelihood functions
@@ -178,9 +176,7 @@ run_mcmc_chain <- function(n_mcmc,
 
     ## calculate proposed prior / lhood / posterior
     prop_lprior <- calc_lprior(prop_pars, lprior_funcs)
-    prop_ll <- filter$run2(save_history = FALSE,
-                           index = vars$index,
-                           pars = as.list(prop_pars))
+    prop_ll <- filter$run2(as.list(prop_pars), vars$index)
     prop_lpost <- prop_lprior + prop_ll
 
     # calculate probability of acceptance

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -27,3 +27,22 @@ assert_strictly_increasing <- function(x, name = deparse(substitute(x))) {
   }
   invisible(x)
 }
+
+
+assert_scalar <- function(x, name = deparse(substitute(x))) {
+  if (length(x) != 1L) {
+    stop(sprintf("'%s' must be a scalar", name), call. = FALSE)
+  }
+  invisible(x)
+}
+
+
+assert_scalar_positive_integer <- function(x, name = deparse(substitute(x))) {
+  force(name)
+  assert_scalar(x, name)
+  x <- assert_integer(x, name)
+  if (x < 1L) {
+    stop(sprintf("'%s' must be at least 1", name), call. = FALSE)
+  }
+  invisible(x)
+}

--- a/man/forecast.Rd
+++ b/man/forecast.Rd
@@ -6,34 +6,11 @@
 \alias{forecast.mcstate_pmcmc_list}
 \title{Sample Grid Scan}
 \usage{
-forecast(
-  x,
-  ...,
-  filter,
-  n_sample_pars = 10,
-  n_particles = 100,
-  forecast_steps = 0,
-  burn_in = 0
-)
+forecast(x, ..., filter, n_sample_pars = 10, forecast_steps = 0, burn_in = 0)
 
-\method{forecast}{mcstate_scan}(
-  x,
-  ...,
-  filter,
-  n_sample_pars = 10,
-  n_particles = 100,
-  forecast_steps = 0
-)
+\method{forecast}{mcstate_scan}(x, ..., filter, n_sample_pars = 10, forecast_steps = 0)
 
-\method{forecast}{mcstate_pmcmc_list}(
-  x,
-  ...,
-  filter,
-  n_sample_pars = 10,
-  n_particles = 100,
-  forecast_steps = 0,
-  burn_in = 1
-)
+\method{forecast}{mcstate_pmcmc_list}(x, ..., filter, n_sample_pars = 10, forecast_steps = 0, burn_in = 1)
 }
 \arguments{
 \item{x}{Output of \code{\link{grid_search}}.}
@@ -48,8 +25,6 @@ forecast(
 proportion to their posterior probability. For a \code{mcstate_pmcmc_list}
 this will be full parameter sets sampled evenly from the chains.
 Integer. This will determine how many trajectories are returned.}
-
-\item{n_particles}{Number of particles. Positive Integer. Default = 100}
 
 \item{forecast_steps}{Number of time steps being forecast. Default = 0}
 

--- a/man/grid_search.Rd
+++ b/man/grid_search.Rd
@@ -4,7 +4,7 @@
 \alias{grid_search}
 \title{Grid search over two parameters}
 \usage{
-grid_search(range, filter, n_particles, tolerance = 0.01, run_params = NULL)
+grid_search(range, filter, tolerance = 0.01)
 }
 \arguments{
 \item{range}{\code{data.frame} describing the parameters to search.
@@ -12,11 +12,7 @@ Must have columns name, min, max, n and target}
 
 \item{filter}{A \code{particle_filter} object to run}
 
-\item{n_particles}{Number of particles. Positive Integer. Default = 100}
-
 \item{tolerance}{Check around edges of the probability matrix}
-
-\item{run_params}{Passed to \code{particle_filter$run}}
 }
 \value{
 List of beta and start date grid values, and

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -89,7 +89,16 @@ Create the particle filter}
 \if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter$new(data, model, compare, index = NULL, initial = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$new(
+  data,
+  model,
+  n_particles,
+  compare,
+  index = NULL,
+  initial = NULL,
+  n_threads = 1L,
+  seed = 1L
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -102,6 +111,8 @@ used for comparison with the simulation.}
 
 \item{\code{model}}{A stochastic model to use.  Must be a
 \code{dust_generator} object.}
+
+\item{\code{n_particles}}{The number of particles to simulate}
 
 \item{\code{compare}}{A comparison function.  Must take arguments
 \code{state}, \code{output}, \code{data} and \code{pars} as arguments
@@ -144,7 +155,15 @@ constructor, i.e., not less than the first element of
 \code{step_start} and not more than \code{step_end}). Your function
 can also return a vector or matrix of \code{state} and not alter
 the starting step, which is equivalent to returning
-\code{list(state = state, step = NULL)}.
+\code{list(state = state, step = NULL)}.}
+
+\item{\code{n_threads}}{Number of threads to use when running the
+simulation. Defaults to 1, and should not be set higher than the
+number of cores available to the machine.}
+
+\item{\code{seed}}{Seed for the random number generator on initial
+creation; must be a positive integer. Note that this is unrelated
+to R's random number generator (see \code{\link{dust}}).
 Run the particle filter}
 }
 \if{html}{\out{</div>}}
@@ -157,10 +176,8 @@ Run the particle filter}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{particle_filter$run(
   pars_model,
-  n_particles,
   save_history = FALSE,
   pars_compare = NULL,
-  run_params = NULL,
   pars_initial = NULL
 )}\if{html}{\out{</div>}}
 }
@@ -173,16 +190,12 @@ which may contain parameters for your model (these might affect
 running and/or initial conditions, depending on your model and
 if you are using \code{initial} / \code{pars_initial} below).}
 
-\item{\code{n_particles}}{The number of particles to simulate}
-
 \item{\code{save_history}}{Logical, indicating if the history of all
 particles should be saved}
 
 \item{\code{pars_compare}}{Optional parameters to use when applying
 the \code{compare} function.  These parameters will be passed as
 the 4th argument to \code{compare}.}
-
-\item{\code{run_params}}{List containing seed and n_threads for use with dust}
 
 \item{\code{pars_initial}}{Parameters passed through to the \code{initial}
 function (if provided).}
@@ -200,30 +213,18 @@ Run the particle filter, modifying parameters
 \if{latex}{\out{\hypertarget{method-run2}{}}}
 \subsection{Method \code{run2()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run2(
-  n_particles,
-  save_history = FALSE,
-  index,
-  pars,
-  run_params = NULL
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run2(save_history = FALSE, index, pars)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{n_particles}}{The number of particles to simulate}
-
 \item{\code{save_history}}{Logical, indicating if the history of all
 particles should be saved}
 
 \item{\code{index}}{A parameter index}
 
-\item{\code{pars}}{A list of parameters}
-
-\item{\code{run_params}}{List containing seed and n_threads
-for use with dust
-
+\item{\code{pars}}{A list of parameters
 Create predicted trajectories, based on the final point of a
 run with the particle filter}
 }

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -205,7 +205,11 @@ particles should be saved}
 \subsection{Returns}{
 A single numeric value representing the log-likelihood
 (\code{-Inf} if the model is impossible)
-Run the particle filter, modifying parameters
+Run the particle filter, allocating a vector of parameters across
+the different tuneable components (model, initial and compare).
+This is a wrapper around the \code{$run()} method, used by
+\code{\link{pmcmc}} and \code{\link{grid_search}} though it can
+be used directly (the name may change in future).
 }
 }
 \if{html}{\out{<hr>}}
@@ -213,18 +217,20 @@ Run the particle filter, modifying parameters
 \if{latex}{\out{\hypertarget{method-run2}{}}}
 \subsection{Method \code{run2()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run2(save_history = FALSE, index, pars)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run2(pars, index, save_history = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{pars}}{A list of parameters}
+
+\item{\code{index}}{A parameter index; this must be a list with elements
+\code{pars_model}, \code{pars_compare} and \code{pars_initial},
+indicating the argument of \code{$run()} they apply to.}
+
 \item{\code{save_history}}{Logical, indicating if the history of all
-particles should be saved}
-
-\item{\code{index}}{A parameter index}
-
-\item{\code{pars}}{A list of parameters
+particles should be saved.
 Create predicted trajectories, based on the final point of a
 run with the particle filter}
 }

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -45,9 +45,9 @@ compare <- function(state, prev_state, observed, pars = NULL) {
   dpois(x = incidence_observed, lambda = lambda, log = TRUE)
 }
 
-# Construct the particle_filter object:
-p <- particle_filter$new(data, gen, compare)
-p$run(list(), 100, TRUE)
+# Construct the particle_filter object with 100 particles
+p <- particle_filter$new(data, gen, 100, compare)
+p$run(list(), save_history = TRUE)
 
 # Our simulated trajectories, with the "real" data superimposed
 matplot(data_raw$day, t(p$history[1, , -1]), type = "l",

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -47,7 +47,7 @@ compare <- function(state, prev_state, observed, pars = NULL) {
 
 # Construct the particle_filter object with 100 particles
 p <- particle_filter$new(data, gen, 100, compare)
-p$run(list(), save_history = TRUE)
+p$run(save_history = TRUE)
 
 # Our simulated trajectories, with the "real" data superimposed
 matplot(data_raw$day, t(p$history[1, , -1]), type = "l",
@@ -175,10 +175,10 @@ Run the particle filter}
 \subsection{Method \code{run()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{particle_filter$run(
-  pars_model,
-  save_history = FALSE,
+  pars_model = NULL,
   pars_compare = NULL,
-  pars_initial = NULL
+  pars_initial = NULL,
+  save_history = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -190,15 +190,15 @@ which may contain parameters for your model (these might affect
 running and/or initial conditions, depending on your model and
 if you are using \code{initial} / \code{pars_initial} below).}
 
-\item{\code{save_history}}{Logical, indicating if the history of all
-particles should be saved}
-
 \item{\code{pars_compare}}{Optional parameters to use when applying
 the \code{compare} function.  These parameters will be passed as
 the 4th argument to \code{compare}.}
 
 \item{\code{pars_initial}}{Parameters passed through to the \code{initial}
 function (if provided).}
+
+\item{\code{save_history}}{Logical, indicating if the history of all
+particles should be saved}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/pmcmc.Rd
+++ b/man/pmcmc.Rd
@@ -8,10 +8,8 @@ pmcmc(
   mcmc_range,
   lprior_funcs,
   filter,
-  n_particles,
   n_mcmc,
   proposal_kernel,
-  run_params = NULL,
   output_proposals = FALSE,
   n_chains = 1
 )
@@ -30,13 +28,9 @@ Each value must be a function which takes named parameter vector as
 
 \item{filter}{A particle filter to sample}
 
-\item{n_particles}{Number of particles}
-
 \item{n_mcmc}{Number of MCMC steps}
 
 \item{proposal_kernel}{named matrix of proposal covariance for parameters}
-
-\item{run_params}{List of parameters for \code{particle_filter$run}}
 
 \item{output_proposals}{Logical indicating whether proposed parameter
 jumps should be output along with results}

--- a/tests/testthat/test-forecasts.R
+++ b/tests/testthat/test-forecasts.R
@@ -17,11 +17,10 @@ test_that("Sampling and forecasting from a grid search", {
   forecast_steps <- 0
 
   set.seed(1)
-  grid_res <- grid_search(range, p, n_particles)
+  grid_res <- grid_search(range, p)
   forecast_res <- forecast(grid_res,
                            filter = p,
                            n_sample_pars = n_sample_pars,
-                           n_particles = n_particles,
                            forecast_steps = forecast_steps)
 
   # check structure is as expected
@@ -62,7 +61,6 @@ test_that("Sampling and forecasting from a grid search", {
   forecast_res <- forecast(grid_res,
                            filter = p,
                            n_sample_pars = n_sample_pars,
-                           n_particles = n_particles,
                            forecast_steps = forecast_steps)
   for (i in seq_len(n_sample_pars)) {
     # 5 quantities, 101 steps
@@ -89,7 +87,7 @@ test_that("Sampling and forecasting from an MCMC", {
 
   dat <- example_sir()
   n_particles <- 20
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, n_particles,
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
   n_mcmc <- 100
   n_chains <- 2
@@ -97,12 +95,11 @@ test_that("Sampling and forecasting from an MCMC", {
   forecast_steps <- 0
 
   set.seed(1)
-  mcmc_res <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
-             n_chains = n_chains)
+  mcmc_res <- pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
+                    n_chains = n_chains)
   forecast_res <- forecast(mcmc_res,
                            filter = p,
                            n_sample_pars = n_sample_pars,
-                           n_particles = n_particles,
                            forecast_steps = forecast_steps,
                            burn_in = 10)
 
@@ -144,7 +141,6 @@ test_that("Sampling and forecasting from an MCMC", {
   forecast_res <- forecast(mcmc_res,
                            filter = p,
                            n_sample_pars = n_sample_pars,
-                           n_particles = n_particles,
                            forecast_steps = forecast_steps)
   for (i in seq_len(n_sample_pars)) {
     # 5 quantities, 101 steps

--- a/tests/testthat/test-forecasts.R
+++ b/tests/testthat/test-forecasts.R
@@ -9,9 +9,10 @@ test_that("Sampling and forecasting from a grid search", {
                       stringsAsFactors = FALSE)
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
-  state <- dat$y0
   n_particles <- 100
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
+  state <- dat$y0
   n_sample_pars <- 10
   forecast_steps <- 0
 
@@ -87,8 +88,9 @@ test_that("Sampling and forecasting from an MCMC", {
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- range$name
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 20
+  p <- particle_filter$new(dat$data, dat$model, dat$compare, n_particles,
+                           index = dat$index)
   n_mcmc <- 100
   n_chains <- 2
   n_sample_pars <- 10

--- a/tests/testthat/test-grid-search.R
+++ b/tests/testthat/test-grid-search.R
@@ -9,8 +9,9 @@ test_that("Simple grid search with SIR model", {
                       target = "pars_model")
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 100
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
 
   res <- grid_search(range, p, n_particles)
 
@@ -39,8 +40,9 @@ test_that("SIR model parameters are can be inferred correctly", {
   # * beta = 0.2 (transmission)
   # * g = 0.1 (recovery)
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 100
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
 
   res <- grid_search(range, p, n_particles)
 
@@ -68,9 +70,9 @@ test_that("Start date can be sampled", {
     list(step = pars[["step_start"]])
   }
 
-  p <- particle_filter$new(data, dat$model, dat$compare, index = dat$index,
-                           initial = initial)
   n_particles <- 100
+  p <- particle_filter$new(data, dat$model, n_particles, dat$compare,
+                           index = dat$index, initial = initial)
 
   set.seed(1)
   grid_res <- grid_search(range, p, n_particles)
@@ -87,8 +89,10 @@ test_that("pars_compare can be sampled", {
 
   dat <- example_sir()
 
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 100
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
+
 
   set.seed(1)
   grid_res <- grid_search(range, p, n_particles)

--- a/tests/testthat/test-grid-search.R
+++ b/tests/testthat/test-grid-search.R
@@ -13,7 +13,7 @@ test_that("Simple grid search with SIR model", {
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
 
-  res <- grid_search(range, p, n_particles)
+  res <- grid_search(range, p)
 
   expect_is(res, "mcstate_scan")
 
@@ -44,7 +44,7 @@ test_that("SIR model parameters are can be inferred correctly", {
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
 
-  res <- grid_search(range, p, n_particles)
+  res <- grid_search(range, p)
 
   # Correct parameter estimate is the highest
   expect_true(res$renorm_mat_ll[2, 2] == max(res$renorm_mat_ll))
@@ -75,7 +75,7 @@ test_that("Start date can be sampled", {
                            index = dat$index, initial = initial)
 
   set.seed(1)
-  grid_res <- grid_search(range, p, n_particles)
+  grid_res <- grid_search(range, p)
   expect_true(grid_res$renorm_mat_ll[2, 3] == max(grid_res$renorm_mat_ll))
 })
 
@@ -95,7 +95,7 @@ test_that("pars_compare can be sampled", {
 
 
   set.seed(1)
-  grid_res <- grid_search(range, p, n_particles)
+  grid_res <- grid_search(range, p)
   ## NOTE: this is a fragile test - I've had to update the index twice
   expect_true(grid_res$renorm_mat_ll[2, 1] == max(grid_res$renorm_mat_ll))
 })

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -5,7 +5,7 @@ test_that("run particle filter on sir model", {
   n_particles <- 42
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
-  res <- p$run(list())
+  res <- p$run()
   expect_is(res, "numeric")
 
   expect_is(p$state, "matrix")
@@ -22,11 +22,11 @@ test_that("continuing a particle filter continues the RNG", {
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
   set.seed(1) # affects sample() used for filtering
-  res <- p$run(list())
+  res <- p$run()
   expect_is(res, "numeric")
 
   set.seed(1)
-  res2 <- p$run(list())
+  res2 <- p$run()
   expect_true(res2 != res)
 })
 
@@ -44,9 +44,9 @@ test_that("run particle filter without index", {
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, compare2)
 
   set.seed(1)
-  ll1 <- p1$run(list())
+  ll1 <- p1$run()
   set.seed(1)
-  ll2 <- p2$run(list())
+  ll2 <- p2$run()
   expect_identical(ll1, ll2)
 
   expect_equal(dim(p1$state), c(3, n_particles))
@@ -59,7 +59,7 @@ test_that("particle filter likelihood is worse with worse parameters", {
   n_particles <- 100
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
-  ll1 <- p$run(list())
+  ll1 <- p$run()
   ll2 <- p$run(pars_model = list(gamma = 1, beta = 1))
   expect_true(ll1 > ll2)
 })
@@ -80,7 +80,7 @@ test_that("stop simulation when likelihood is impossible", {
 
   p <- particle_filter$new(dat$data, dat$model, n_particles, compare,
                            index = dat$index)
-  res <- p$run(list(), save_history = TRUE)
+  res <- p$run(save_history = TRUE)
   expect_equal(res, -Inf)
 
   i <- (which(dat$data$incidence > 15)[[1]] + 2):steps
@@ -130,11 +130,11 @@ test_that("predict", {
   set.seed(1)
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
-  run1 <- p1$run(list(), save_history = TRUE)
+  run1 <- p1$run(save_history = TRUE)
   set.seed(1)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
-  run2 <- p2$run(list(), save_history = TRUE)
+  run2 <- p2$run(save_history = TRUE)
 
   t <- 0:10
   res1 <- p1$predict(t)
@@ -164,9 +164,9 @@ test_that("predict particle filter without index", {
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, compare2)
 
   set.seed(1)
-  ll1 <- p1$run(list(), save_history = TRUE)
+  ll1 <- p1$run(save_history = TRUE)
   set.seed(1)
-  ll2 <- p2$run(list(), save_history = TRUE)
+  ll2 <- p2$run(save_history = TRUE)
   expect_identical(ll1, ll2)
 
   t <- 0:10
@@ -191,7 +191,7 @@ test_that("can't append predictions without history", {
   n_particles <- 42
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
-  res <- p$run(list(), save_history = FALSE)
+  res <- p$run(save_history = FALSE)
   expect_error(p$predict(0:10, TRUE), "Can't append without history")
 })
 
@@ -201,7 +201,7 @@ test_that("prediction time must start at zero", {
   n_particles <- 42
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
-  res <- p$run(list(), save_history = FALSE)
+  res <- p$run(save_history = FALSE)
   expect_error(p$predict(1:10), "Expected first 't' element to be zero")
 })
 
@@ -211,7 +211,7 @@ test_that("can't run predictions twice", {
   n_particles <- 42
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
-  res <- p$run(list(), save_history = FALSE)
+  res <- p$run(save_history = FALSE)
   res <- p$predict(0:10)
   expect_error(p$predict(0:10), "Can't yet run predict multiple times")
 })
@@ -250,10 +250,10 @@ test_that("Control the comparison function", {
                            index = dat$index)
 
   pars_compare <- list(exp_noise = 1)
-  ll1 <- p$run(list(), pars_compare = pars_compare)
+  ll1 <- p$run(pars_compare = pars_compare)
 
   pars_compare <- list(exp_noise = 0.01)
-  ll2 <- p$run(list(), pars_compare = pars_compare)
+  ll2 <- p$run(pars_compare = pars_compare)
   expect_true(ll2 < ll1)
 })
 
@@ -275,18 +275,18 @@ test_that("Control the starting point of the simulation", {
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   set.seed(1)
-  ll1 <- p1$run(list())
+  ll1 <- p1$run()
 
   ## Tuning the start date
   p2 <- particle_filter$new(data, dat$model, n_particles, dat$compare,
                             index = dat$index, initial = initial)
   set.seed(1)
-  ll2 <- p2$run(list(), pars_initial = as.integer(offset))
+  ll2 <- p2$run(pars_initial = as.integer(offset))
   expect_identical(ll1, ll2)
 
   ## Running from the beginning is much worse:
   set.seed(1)
-  ll3 <- p2$run(list(), pars_initial = 0L)
+  ll3 <- p2$run(pars_initial = 0L)
   expect_true(ll3 < ll1)
 })
 
@@ -352,7 +352,7 @@ test_that("check for unconsumed pars_initial", {
   p <- particle_filter$new(dat$data, dat$model, 100, dat$compare,
                            index = dat$index)
   expect_error(
-    p$run(list(), 100, pars_initial = list(1, 2)),
+    p$run(pars_initial = list(1, 2)),
     "'pars_initial' was provided but you do not have")
 })
 
@@ -362,7 +362,7 @@ test_that("we do not reorder particles when compare is NULL", {
   n_particles <- 42
   p <- particle_filter$new(dat$data, dat$model, n_particles,
                            function(...) NULL, index = dat$index)
-  res <- p$run(list())
+  res <- p$run()
   expect_equal(res, 0)
   expect_equal(p$unique_particles, rep(n_particles, 101))
 })
@@ -378,13 +378,13 @@ test_that("initialise with simple state", {
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index, initial = initial)
 
-  ll1 <- p$run(list(), pars_initial = list(I0 = 200), save_history = TRUE)
+  ll1 <- p$run(pars_initial = list(I0 = 200), save_history = TRUE)
   expect_equal(p$history[, , 1],
                matrix(c(1000, 200, 0), 3, n_particles))
-  ll2 <- p$run(list(), pars_initial = list(I0 = 1), save_history = TRUE)
+  ll2 <- p$run(pars_initial = list(I0 = 1), save_history = TRUE)
   expect_equal(p$history[, , 1],
                matrix(c(1000, 1, 0), 3, n_particles))
-  ll3 <- p$run(list(), pars_initial = list(I0 = 10), save_history = TRUE)
+  ll3 <- p$run(pars_initial = list(I0 = 10), save_history = TRUE)
   expect_equal(p$history[, , 1],
                matrix(c(1000, 10, 0), 3, n_particles))
 
@@ -414,7 +414,7 @@ test_that("initialise with complex state", {
   pars <- list(I0 = 10)
 
   set.seed(1)
-  ll <- p$run(list(), pars_initial = pars, save_history = TRUE)
+  ll <- p$run(pars_initial = pars, save_history = TRUE)
   expect_equal(p$history[, , 1],
                initial(NULL, n_particles, pars)[1:3, ])
 })
@@ -445,7 +445,7 @@ test_that("Control the starting point of the simulation", {
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   set.seed(1)
-  ll1 <- p1$run(list())
+  ll1 <- p1$run()
 
   ## Then tune the start date to get the same effect:
   initial <- function(info, n_particles, pars) {
@@ -457,14 +457,14 @@ test_that("Control the starting point of the simulation", {
   p2 <- particle_filter$new(data, dat$model, n_particles, dat$compare,
                             index = dat$index, initial = initial)
   set.seed(1)
-  ll2 <- p2$run(list(), pars_initial = list(I0 = 10, step = offset),
+  ll2 <- p2$run(pars_initial = list(I0 = 10, step = offset),
                 save_history = TRUE)
 
   expect_identical(ll1, ll2)
 
   ## Running from the beginning is much worse:
   set.seed(1)
-  ll3 <- p2$run(list(), pars_initial = list(I0 = 10, step = 0),
+  ll3 <- p2$run(pars_initial = list(I0 = 10, step = 0),
                 save_history = TRUE)
   expect_true(ll3 < ll1)
 })
@@ -505,7 +505,7 @@ test_that("Variable initial starting point of the simulation", {
                            index = dat$index, initial = initial)
   pars <- list(I0 = 10, step_mean = 20, step_offset = 400)
   set.seed(1)
-  ll <- p$run(list(), pars_initial = pars, save_history = TRUE)
+  ll <- p$run(pars_initial = pars, save_history = TRUE)
   expect_equal(ll, 0)
 
   mod <- p$model$new(list(), step = 0, n_particles = n_particles)

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -292,18 +292,16 @@ test_that("Control the starting point of the simulation", {
 
 
 test_that("control filter", {
-  expect_equal(
-    validate_dust_params(NULL),
-    list(n_threads = 1L, seed = 1L))
-  expect_equal(
-    validate_dust_params(list(n_threads = 0, seed = 0)),
-    list(n_threads = 1L, seed = 1L))
-  expect_equal(
-    validate_dust_params(list(n_threads = 2, seed = 8)),
-    list(n_threads = 2L, seed = 8L))
-  expect_equal(
-    validate_dust_params(list(n_threads = 2, seed = 8.5)),
-    list(n_threads = 2L, seed = 8L))
+  dat <- example_sir()
+  expect_error(
+    particle_filter$new(dat$data, dat$model, 0, dat$compare),
+    "'n_particles' must be at least 1")
+  expect_error(
+    particle_filter$new(dat$data, dat$model, 1, dat$compare, seed = -1),
+    "'seed' must be at least 1")
+  expect_error(
+    particle_filter$new(dat$data, dat$model, 1, dat$compare, n_threads = -1),
+    "'n_threads' must be at least 1")
 })
 
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -26,7 +26,7 @@ test_that("continuing a particle filter continues the RNG", {
   expect_is(res, "numeric")
 
   set.seed(1)
-  res2 <- p$run(list(), n_particles)
+  res2 <- p$run(list())
   expect_true(res2 != res)
 })
 
@@ -80,7 +80,7 @@ test_that("stop simulation when likelihood is impossible", {
 
   p <- particle_filter$new(dat$data, dat$model, n_particles, compare,
                            index = dat$index)
-  res <- p$run(list(), TRUE)
+  res <- p$run(list(), save_history = TRUE)
   expect_equal(res, -Inf)
 
   i <- (which(dat$data$incidence > 15)[[1]] + 2):steps

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -180,7 +180,7 @@ test_that("predict particle filter without index", {
 
 test_that("can't predict until model has been run", {
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, 100,
+  p <- particle_filter$new(dat$data, dat$model, 100, dat$compare,
                            index = dat$index)
   expect_error(p$predict(0:10), "Particle filter has not been run")
 })

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -21,7 +21,7 @@ test_that("MCMC can run", {
 
   # A single chain
   n_chains <- 1
-  mcmc_results <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  mcmc_results <- pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                         n_chains = n_chains)
 
   expect_equal(class(mcmc_results), "mcstate_pmcmc")
@@ -41,7 +41,7 @@ test_that("MCMC can run", {
   # Multiple chains
   n_chains <- 3
   burn_in <- 10
-  multi_chain <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  multi_chain <- pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                         n_chains = n_chains)
 
   expect_equal(class(multi_chain), "mcstate_pmcmc_list")
@@ -80,7 +80,7 @@ test_that("MCMC doesn't move away from correct parameters", {
   n_chains <- 1
 
   set.seed(1)
-  mcmc_results <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  mcmc_results <- pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                         n_chains = n_chains)
 
   expect_lt(abs(mean(mcmc_results$results$beta) - 0.2), 0.03)
@@ -124,7 +124,7 @@ test_that("MCMC runs on different targets", {
 
   # A single chain
   n_chains <- 1
-  mcmc_results <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  mcmc_results <- pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                         n_chains = n_chains)
 
   expect_equal(class(mcmc_results), "mcstate_pmcmc")
@@ -189,7 +189,7 @@ test_that("MCMC jumps behave as expected", {
                            index = dat$index)
   n_mcmc <- 500
   n_chains <- 1
-  mcmc_results <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  mcmc_results <- pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
              n_chains = n_chains, output_proposals = TRUE)
 
   expect_equal(object = mcmc_results$results$beta,
@@ -207,7 +207,7 @@ test_that("MCMC jumps behave as expected", {
                         dimnames = list(
                           range$name,
                           range$name))
-  no_covar_results <- pmcmc(range, lprior, p, n_particles, n_mcmc,
+  no_covar_results <- pmcmc(range, lprior, p, n_mcmc,
                             proposal_kernel, n_chains = n_chains,
                             output_proposals = TRUE)
   set.seed(1)
@@ -217,7 +217,7 @@ test_that("MCMC jumps behave as expected", {
                         dimnames = list(
                           range$name,
                           range$name))
-  covar_results <- pmcmc(range, lprior, p, n_particles, n_mcmc,
+  covar_results <- pmcmc(range, lprior, p, n_mcmc,
                          proposal_kernel, n_chains = n_chains,
                          output_proposals = TRUE)
   expect_false(all(covar_results$results == no_covar_results$results))
@@ -319,24 +319,24 @@ test_that("MCMC function input errors", {
   n_mcmc <- 100
 
   n_chains <- 1
-  expect_error(pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  expect_error(pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                      n_chains = n_chains, output_proposals = "yes_please"),
                "output_proposals must be either TRUE or FALSE")
 
   # bad priors
   lprior <- list("beta" = function(pars) log(1e-10))
-  expect_error(pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  expect_error(pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                      n_chains = n_chains),
                "All sampled parameters must have a defined prior")
   lprior <- list("beta" = function(pars) c(log(1e-10), log(1e-10)),
                  "gamma" = function(pars) c(0, 0))
-  expect_error(pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  expect_error(pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                      n_chains = n_chains),
                paste0("lprior_funcs must return a single numeric representing ",
                "the log prior"))
   lprior <- list("beta" = function(pars) log(0),
                  "gamma" = function(pars) 0)
-  expect_error(pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  expect_error(pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                      n_chains = n_chains),
                "initial parameters are not compatible with supplied prior")
 
@@ -345,7 +345,7 @@ test_that("MCMC function input errors", {
                  "gamma" = function(pars) log(1e-10))
   proposal_kernel <- diag(1) * 0.01^2
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- range$name[1]
-  expect_error(pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  expect_error(pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                      n_chains = n_chains),
                paste0("proposal_kernel must be a matrix or vector with names ",
                       "corresponding to the parameters being sampled"))
@@ -374,7 +374,7 @@ test_that("Master chain errors", {
                            index = dat$index)
   n_mcmc <- 10
   n_chains <- 3
-  multi_chain <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
+  multi_chain <- pmcmc(range, lprior, p, n_mcmc, proposal_kernel,
                        n_chains = n_chains)
 
   expect_error(create_master_chain(multi_chain, burn_in = -1L),

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -14,8 +14,9 @@ test_that("MCMC can run", {
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- range$name
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 10
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
   n_mcmc <- 100
 
   # A single chain
@@ -72,8 +73,9 @@ test_that("MCMC doesn't move away from correct parameters", {
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- range$name
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 20
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
   n_mcmc <- 500
   n_chains <- 1
 
@@ -115,9 +117,9 @@ test_that("MCMC runs on different targets", {
   data[c("step_start", "step_end")] <-
     data[c("step_start", "step_end")] + offset
   data$step_start[[1]] <- 0
-  p <- particle_filter$new(data, dat$model, dat$compare, index = dat$index,
-                           initial = initial)
   n_particles <- 10
+  p <- particle_filter$new(data, dat$model, n_particles, dat$compare,
+                           index = dat$index, initial = initial)
   n_mcmc <- 10
 
   # A single chain
@@ -182,8 +184,9 @@ test_that("MCMC jumps behave as expected", {
                           range$name))
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 20
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
   n_mcmc <- 500
   n_chains <- 1
   mcmc_results <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,
@@ -310,8 +313,9 @@ test_that("MCMC function input errors", {
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- range$name
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 10
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
   n_mcmc <- 100
 
   n_chains <- 1
@@ -365,8 +369,9 @@ test_that("Master chain errors", {
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- range$name
 
   dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, dat$compare, index = dat$index)
   n_particles <- 10
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index)
   n_mcmc <- 10
   n_chains <- 3
   multi_chain <- pmcmc(range, lprior, p, n_particles, n_mcmc, proposal_kernel,

--- a/tests/testthat/test-utils-assert.R
+++ b/tests/testthat/test-utils-assert.R
@@ -21,3 +21,21 @@ test_that("assert_strictly_increasing", {
   expect_error(assert_strictly_increasing(c(0, -1, -2)),
                "must be strictly increasing")
 })
+
+
+test_that("assert_scalar", {
+  value <- NULL
+  expect_silent(assert_scalar(1))
+  expect_error(assert_scalar(value), "'value' must be a scalar")
+  expect_error(assert_scalar(1:2), "must be a scalar")
+})
+
+
+test_that("assert_scalar_positive_integer", {
+  expect_equal(assert_scalar_positive_integer(1L), 1L)
+  expect_equal(assert_scalar_positive_integer(1000000L), 1000000L)
+
+  value <- 0L
+  expect_error(assert_scalar_positive_integer(value),
+               "'value' must be at least 1")
+})


### PR DESCRIPTION
This PR rationalises arguments to the particle filter and functions that use it

* arguments `n_particles`, `n_threads` and `seed` are arguments to the initialise method
* the validation of these is made a bit stricter and less helpful
* these arguments come out of pmcmc, grid_search and forecast
* the remaining `pars_*` arguments to `run` get reordered, and *all* have a default of `NULL`, which simplifies use in the tests
* the arguments to run2 have been reversed to put the ones without defaults and which change fastest first

It turns out that they could never have been set after we changed to allow the RNG to continue a few PRs ago, so they were only read during the *first* creation of the filter. This is now much more explicit, and simplifies the interface a bunch.

Fixes #21 
~Builds on #30 so should be merged after that~