### PR TITLE
i38: port roxygen to use markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,4 @@ Suggests:
     vctrs,
     withr
 RoxygenNote: 7.1.0
+Roxygen: list(markdown = TRUE)

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -1,6 +1,6 @@
 ##' @title Particle filter
 ##'
-##' @description Create a \code{particle_filter} object for running
+##' @description Create a `particle_filter` object for running
 ##'   and interacting with a particle filter.  A higher-level
 ##'   interface will be implemented later.
 ##'
@@ -96,36 +96,36 @@ particle_filter <- R6::R6Class(
     ##' @description Create the particle filter
     ##'
     ##' @param data The data set to be used for the particle filter,
-    ##' created by \code{\link{particle_filter_data}}. This is essentially
-    ##' a \code{\link{data.frame}} with at least columns \code{step_start}
-    ##' and \code{step_end}, along with any additional data used in the
-    ##' \code{compare} function, and additional information about how your
+    ##' created by [particle_filter_data()]. This is essentially
+    ##' a [data.frame()] with at least columns `step_start`
+    ##' and `step_end`, along with any additional data used in the
+    ##' `compare` function, and additional information about how your
     ##' steps relate to time.
     ##'
     ##' @param model A stochastic model to use.  Must be a
-    ##' \code{dust_generator} object.
+    ##' `dust_generator` object.
     ##'
     ##' @param n_particles The number of particles to simulate
     ##'
     ##' @param compare A comparison function.  Must take arguments
-    ##' \code{state}, \code{output}, \code{data} and \code{pars} as arguments
+    ##' `state`, `output`, `data` and `pars` as arguments
     ##' (though the arguments may have different names).
-    ##' \code{state} is the simulated model state (a matrix with as
+    ##' `state` is the simulated model state (a matrix with as
     ##' many rows as there are state variables and as many columns as
-    ##' there are particles.  \code{output} is the output variables, if
-    ##' the model produces them (\code{NULL} otherwise) and \code{data}
-    ##' is a \code{list} of observed data corresponding to the current
-    ##' time's row in the \code{data} object provided here in the
-    ##' constructor.  \code{pars} is any additional parameters passed
-    ##' through to the comparison function (via the \code{pars}
-    ##' argument to \code{$run}).
+    ##' there are particles.  `output` is the output variables, if
+    ##' the model produces them (`NULL` otherwise) and `data`
+    ##' is a `list` of observed data corresponding to the current
+    ##' time's row in the `data` object provided here in the
+    ##' constructor.  `pars` is any additional parameters passed
+    ##' through to the comparison function (via the `pars`
+    ##' argument to `$run`).
     ##'
     ##' @param index An index function. This is used to compute the
     ##' "interesting" indexes of your model. It must be a function of
     ##' one argument, which will be the result of calling the
-    ##' \code{$info()} method on your model. It should return a list
-    ##' with elements \code{run} (indices to return at the end of each
-    ##' run, passed through to your compare function) and \code{state}
+    ##' `$info()` method on your model. It should return a list
+    ##' with elements `run` (indices to return at the end of each
+    ##' run, passed through to your compare function) and `state`
     ##' (indices to return if saving state). These indices can overlap
     ##' but do not have to. This argument is optional but using it will
     ##' likely speed up your simulation if you have more than a few
@@ -133,22 +133,22 @@ particle_filter <- R6::R6Class(
     ##' forth.
     ##'
     ##' @param initial A function to generate initial conditions. If
-    ##' given, then this function must accept 3 arguments: \code{info}
-    ##' (the result of calling \code{$info()} as for \code{index}),
-    ##' \code{n_particles} (the number of particles that the particle
-    ##' filter is using) and \code{pars} (parameters passed in in the
-    ##' \code{$run} method via the \code{pars} argument).  It
-    ##' must return a list, which can have the elements \code{state}
+    ##' given, then this function must accept 3 arguments: `info`
+    ##' (the result of calling `$info()` as for `index`),
+    ##' `n_particles` (the number of particles that the particle
+    ##' filter is using) and `pars` (parameters passed in in the
+    ##' `$run` method via the `pars` argument).  It
+    ##' must return a list, which can have the elements `state`
     ##' (initial model state, passed to the particle filter - either a
     ##' vector or a matrix, and overriding the initial conditions
-    ##' provided by your model) and \code{step} (the initial step,
+    ##' provided by your model) and `step` (the initial step,
     ##' overriding the first step of your data - this must occur within
-    ##' your first epoch in your \code{data} provided to the
+    ##' your first epoch in your `data` provided to the
     ##' constructor, i.e., not less than the first element of
-    ##' \code{step_start} and not more than \code{step_end}). Your function
-    ##' can also return a vector or matrix of \code{state} and not alter
+    ##' `step_start` and not more than `step_end`). Your function
+    ##' can also return a vector or matrix of `state` and not alter
     ##' the starting step, which is equivalent to returning
-    ##' \code{list(state = state, step = NULL)}.
+    ##' `list(state = state, step = NULL)`.
     ##'
     ##' @param n_threads Number of threads to use when running the
     ##' simulation. Defaults to 1, and should not be set higher than the
@@ -156,7 +156,7 @@ particle_filter <- R6::R6Class(
     ##'
     ##' @param seed Seed for the random number generator on initial
     ##' creation; must be a positive integer. Note that this is unrelated
-    ##' to R's random number generator (see \code{\link{dust}}).
+    ##' to R's random number generator (see [`dust`]).
     initialize = function(data, model, n_particles, compare,
                           index = NULL, initial = NULL,
                           n_threads = 1L, seed = 1L) {
@@ -190,21 +190,21 @@ particle_filter <- R6::R6Class(
     ##' Run the particle filter
     ##'
     ##' @param pars A list representing parameters. This will be passed as
-    ##' the \code{pars} argument to your model, to your \code{compare}
-    ##' function, and (if using) to your \code{initial} function. It must
-    ##' be an R list (not vector or \code{NULL}) because that is what a
-    ##' dust model currently requires on initialisation or \code{$reset} - we
+    ##' the `pars` argument to your model, to your `compare`
+    ##' function, and (if using) to your `initial` function. It must
+    ##' be an R list (not vector or `NULL`) because that is what a
+    ##' dust model currently requires on initialisation or `$reset` - we
     ##' may relax this later. You may want to put your observation and
     ##' initial parameters under their own keys (e.g.,
-    ##' \code{pars$initial$whatever}), but this is up to you. Extra keys
+    ##' `pars$initial$whatever`), but this is up to you. Extra keys
     ##' are silently ignored by dust models.
     ##'
     ##' @param save_history Logical, indicating if the history of all
     ##' particles should be saved. If saving history, then it can be
-    ##' queried later with the \code{$history} method on the object.
+    ##' queried later with the `$history` method on the object.
     ##'
     ##' @return A single numeric value representing the log-likelihood
-    ##' (\code{-Inf} if the model is impossible)
+    ##' (`-Inf` if the model is impossible)
     run = function(pars = list(), save_history = FALSE) {
       compare <- private$compare
       steps <- private$steps
@@ -325,16 +325,16 @@ particle_filter <- R6::R6Class(
     },
 
     ##' @description Extract the particle trajectories. Requires that
-    ##' the model was run with \code{save_history = TRUE}, which does
+    ##' the model was run with `save_history = TRUE`, which does
     ##' incur a performance cost. This method will throw an error if
-    ##' the model has not run, or was run without \code{save_history =
-    ##' TRUE}. Returns a 3d array with dimensions corresponding to (1)
-    ##' model state, filtered by \code{index$run} if provided, (2)
-    ##' particle (following \code{index_particle} if provided), (3)
+    ##' the model has not run, or was run without `save_history =
+    ##' TRUE`. Returns a 3d array with dimensions corresponding to (1)
+    ##' model state, filtered by `index$run` if provided, (2)
+    ##' particle (following `index_particle` if provided), (3)
     ##' time point.
     ##'
     ##' @param index_particle Optional vector of particle indices to return.
-    ##' If \code{NULL} we return all particles' histories.
+    ##' If `NULL` we return all particles' histories.
     history = function(index_particle = NULL) {
       if (is.null(private$last_model)) {
         stop("Model has not yet been run")

--- a/R/particle_filter_data.R
+++ b/R/particle_filter_data.R
@@ -1,4 +1,4 @@
-##' Prepare data for use with the \code{\link{particle_filter}}.  This
+##' Prepare data for use with the [`particle_filter`].  This
 ##' function is not required to use the particle filter but it helps
 ##' arrange data and be explicit about the off-by-one errors that can
 ##' occur.  It takes as input your data to compare against a model,
@@ -9,32 +9,32 @@
 ##' may be relaxed in future to even steps, or possibly irregular
 ##' steps, but for now this assumption is required.  We assume that
 ##' the data in the first column is recorded at the end of a period of
-##' 1 time unit.  So if you have in the first column \code{time = 10,
-##' data = 100} we assume that the model steps from time 9 to to time
+##' 1 time unit.  So if you have in the first column `time = 10,
+##' data = 100` we assume that the model steps from time 9 to to time
 ##' 10 and at that period the data has value 100.
 ##'
 ##' @title Prepare data for use with particle filter
 ##'
-##' @param data A \code{\link{data.frame}} of data
+##' @param data A [data.frame()] of data
 ##'
-##' @param time The name of a column within \code{data} that
+##' @param time The name of a column within `data` that
 ##'   represents your measure of time.  This column must be
 ##'   integer-like
 ##'
 ##' @param rate The number of model "steps" that occur between each
-##'   time point (in \code{time}).  This must also be integer-like
+##'   time point (in `time`).  This must also be integer-like
 ##'
 ##' @param initial_time Optionally, an initial time to start the model
 ##'   from.  Provide this if you need to burn the model in, or if
 ##'   there is a long period with no data at the beginning of the
 ##'   simulation.  If provided, it must be a non-negative integer and
-##'   must be at most equal to the first value of the \code{time}
-##'   column, minus 1 (i.e., \code{data[[time]] - 1}).
+##'   must be at most equal to the first value of the `time`
+##'   column, minus 1 (i.e., `data[[time]] - 1`).
 ##'
-##' @return A data.frame with new columns \code{step_start} and
-##'   \code{step_end} (required by \code{\link{particle_filter}}),
+##' @return A data.frame with new columns `step_start` and
+##'   `step_end` (required by [`particle_filter`]),
 ##'   along side all previous data except for the time variable, which
-##'   is replaced by new \code{<time>_start} and \code{<time>_end}
+##'   is replaced by new `<time>_start` and `<time>_end`
 ##'   columns.
 ##'
 ##' @export

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -1,12 +1,12 @@
 ##' Run a pmcmc sampler
 ##'
 ##' This is a basic Metropolis-Hastings MCMC sampler.  The
-##' \code{filter} is run with a set of parameters to evaluate the
+##' `filter` is run with a set of parameters to evaluate the
 ##' likelihood. A new set of parameters is proposed, and these
 ##' likelihoods are compared, jumping with probability equal to their
-##' ratio. This is repeated for \code{n_mcmc} proposals.
+##' ratio. This is repeated for `n_mcmc` proposals.
 ##'
-##' While this function is called \code{pmcmc} and requires a particle
+##' While this function is called `pmcmc` and requires a particle
 ##' filter object, there's nothing special about it for particle
 ##' filtering. However, we may need to add things in the future that
 ##' make assumptions about the particle filter, so we have named it
@@ -14,47 +14,47 @@
 ##'
 ##' @title Run a pmcmc sampler
 ##'
-##' @param pars A \code{\link{pmcmc_parameters}} object containing
+##' @param pars A [`pmcmc_parameters`] object containing
 ##'   information about parameters (ranges, priors, proposal kernel,
 ##'   translation functions for use with the particle filter).
 ##'
-##' @param filter A \code{\link{particle_filter}} object
+##' @param filter A [`particle_filter`] object
 ##'
 ##' @param n_steps Number of MCMC steps to run
 ##'
 ##' @param save_state Logical, indicating if the state should be saved
-##'   at the end of the simulation. If \code{TRUE}, then a single
+##'   at the end of the simulation. If `TRUE`, then a single
 ##'   randomly selected particle's state will be collected at the end
 ##'   of each MCMC step. This is the full state (i.e., unaffected by
-##'   and \code{index} used in the particle filter) so that the
+##'   and `index` used in the particle filter) so that the
 ##'   process may be restarted from this point for projections.  If
-##'   \code{save_trajectories} is \code{TRUE} the same particle will
-##'   be selected for each. The default is \code{TRUE}, which will
-##'   cause \code{n_state} * \code{n_steps} of data to be output
-##'   alongside your results. Set this argument to \code{FALSE} to
-##'   save space, or use \code{\link{pmcmc_thin}} after running the
+##'   `save_trajectories` is `TRUE` the same particle will
+##'   be selected for each. The default is `TRUE`, which will
+##'   cause `n_state` * `n_steps` of data to be output
+##'   alongside your results. Set this argument to `FALSE` to
+##'   save space, or use [pmcmc_thin()] after running the
 ##'   MCMC.
 ##'
 ##' @param save_trajectories Logical, indicating if the particle
 ##'   trajectories should be saved during the simulation. If
-##'   \code{TRUE}, then a single randomly selected particle's
+##'   `TRUE`, then a single randomly selected particle's
 ##'   trajectory will be collected at the end of each MCMC step.  This
-##'   is the filtered state (i.e., using the \code{state} component of
-##'   \code{index} provided to the particle filter).  If
-##'   \code{save_state} is \code{TRUE} the same particle will
+##'   is the filtered state (i.e., using the `state` component of
+##'   `index` provided to the particle filter).  If
+##'   `save_state` is `TRUE` the same particle will
 ##'   be selected for each.
 ##'
-##' @return A \code{mcstate_pmcmc} object containing \code{pars}
-##'   (sampled parameters) and \code{probabilities} (log prior, log
+##' @return A `mcstate_pmcmc` object containing `pars`
+##'   (sampled parameters) and `probabilities` (log prior, log
 ##'   likelihood and log posterior values for these
 ##'   probabilities). Two additional fields may be present:
-##'   \code{state} (if \code{return_state} was \code{TRUE}),
+##'   `state` (if `return_state` was `TRUE`),
 ##'   containing the final state of a randomly selected particle at
 ##'   the end of the simulation, for each step (will be a matrix with
-##'   as many rows as your state has variables, and as \code{n_steps +
-##'   1} columns corresponding to each step). \code{trajectories} will
+##'   as many rows as your state has variables, and as `n_steps +
+##'   1` columns corresponding to each step). `trajectories` will
 ##'   include a 3d array of particle trajectories through the
-##'   simulation (if \code{return_trajectories} was \code{TRUE}).
+##'   simulation (if `return_trajectories` was `TRUE`).
 ##'
 ##' @export
 pmcmc <- function(pars, filter, n_steps, save_state = TRUE,

--- a/R/pmcmc_parameters.R
+++ b/R/pmcmc_parameters.R
@@ -1,28 +1,28 @@
 ##' Describe a single parameter for use within the pmcmc. Note that
 ##' the name is not set here, but will end up being naturally defined
-##' when used with \code{\link{pmcmc_parameters}}, which collects
-##' these together for use with \code{\link{pmcmc}}.
+##' when used with [`pmcmc_parameters`], which collects
+##' these together for use with [pmcmc()].
 ##'
 ##' @title Describe single pmcmc parameter
 ##'
 ##' @param initial Initial value for the parameter
 ##'
 ##' @param min Optional minimum value for the parameter (otherwise
-##'   \code{-Inf}). If given, then \code{initial} must be at least this
+##'   `-Inf`). If given, then `initial` must be at least this
 ##'   value.
 ##'
 ##' @param max Optional max value for the parameter (otherwise
-##'   \code{Inf}). If given, then \code{initial} must be at most this
+##'   `Inf`). If given, then `initial` must be at most this
 ##'   value.
 ##'
 ##' @param discrete Logical, indicating if this parameter is
-##'   discrete. If \code{TRUE} then the parameter will be rounded
+##'   discrete. If `TRUE` then the parameter will be rounded
 ##'   after a new parameter is proposed.
 ##'
 ##' @param prior A prior function (if not given an improper flat prior
 ##'   is used - be careful!). It must be a function that takes a
 ##'   single argument, being the value of this parameter. If given,
-##'   then \code{prior(initial)} must evaluate to a finite value.
+##'   then `prior(initial)` must evaluate to a finite value.
 ##'
 ##' @export
 ##' @examples
@@ -62,7 +62,7 @@ pmcmc_parameter <- function(initial, min = -Inf, max = Inf, discrete = FALSE,
 ##' @title pmcmc_parameters
 ##'
 ##' @description Construct parameters for use with
-##'   \code{\link{pmcmc}}. This creates a utility object that is used
+##'   [pmcmc()]. This creates a utility object that is used
 ##'   internally to work with parameters. Most users only need to
 ##'   construct this object, but see the examples for how it can be
 ##'   used.
@@ -108,21 +108,21 @@ pmcmc_parameters <- R6::R6Class(
   public = list(
     ##' @description Create the pmcmc_parameters object
     ##'
-    ##' @param parameters A named \code{list} of
-    ##' \code{\link{pmcmc_parameter}} objects, each of which describe a
+    ##' @param parameters A named `list` of
+    ##' [pmcmc_parameter] objects, each of which describe a
     ##' single parameter in your model.
     ##'
     ##' @param proposal A square proposal distribution corresponding to the
     ##' variance-covariance matrix of a multivariate gaussian distribution
     ##' used to generate new parameters. It must have the same number of
-    ##' rows and columns as there are elements in \code{parameters}, and if
+    ##' rows and columns as there are elements in `parameters`, and if
     ##' named the names must correspond exactly to the names in
-    ##' \code{parameters}. Because it corresponds to a variance-covariance
+    ##' `parameters`. Because it corresponds to a variance-covariance
     ##' matrix it must be symmetric and positive definite.
     ##'
     ##' @param transform An optional transformation function to apply
     ##' to your parameter vector immediately before passing it to the
-    ##' model function. If not given, then \code{\link{as.list}} is
+    ##' model function. If not given, then [as.list] is
     ##' used, as dust models require this. However, if t you need to
     ##' generate derived parameters from those being actively sampled
     ##' you can do arbitrary transformations here.
@@ -181,7 +181,7 @@ pmcmc_parameters <- R6::R6Class(
       names(private$parameters)
     },
 
-    ##' @description Return a \code{data.frame} with information about
+    ##' @description Return a `data.frame` with information about
     ##' parameters (name, min, max, and discrete).
     summary = function() {
       data_frame(name = self$names(),
@@ -193,7 +193,7 @@ pmcmc_parameters <- R6::R6Class(
     ##' Compute the prior for a parameter vector
     ##'
     ##' @param theta a parameter vector in the same order as your
-    ##' parameters were defined in (see \code{$names()} for that order.
+    ##' parameters were defined in (see `$names()` for that order.
     prior = function(theta) {
       lp <- Map(function(p, value) p$prior(value), private$parameters, theta)
       sum(list_to_numeric(lp))
@@ -203,10 +203,10 @@ pmcmc_parameters <- R6::R6Class(
     ##' vector. This proposes a new parameter vector given your current
     ##' vector and the variance-covariance matrix of your proposal
     ##' kernel, discretises any discrete values, and reflects bounded
-    ##' parameters until they lie within \code{min}:\code{max}.
+    ##' parameters until they lie within `min`:`max`.
     ##'
     ##' @param theta a parameter vector in the same order as your
-    ##' parameters were defined in (see \code{$names()} for that order.
+    ##' parameters were defined in (see `$names()` for that order.
     propose = function(theta) {
       theta <- private$proposal(theta)
       theta[private$discrete] <- round(theta[private$discrete])
@@ -216,7 +216,7 @@ pmcmc_parameters <- R6::R6Class(
     ##' Apply the model transformation function to a parameter vector.
     ##'
     ##' @param theta a parameter vector in the same order as your
-    ##' parameters were defined in (see \code{$names()} for that order.
+    ##' parameters were defined in (see `$names()` for that order.
     model = function(theta) {
       private$transform(theta)
     }

--- a/R/pmcmc_tools.R
+++ b/R/pmcmc_tools.R
@@ -1,12 +1,12 @@
-##' Thin results of running \code{\link{pmcmc}}. This function may be
-##' useful before using \code{\link{pmcmc_predict}}, or before saving
+##' Thin results of running [pmcmc()]. This function may be
+##' useful before using [pmcmc_predict()], or before saving
 ##' pmcmc output to disk.
 ##'
 ##' @title Thin a pmcmc chain
-##' @param object Results of running \code{\link{pmcmc}}
+##' @param object Results of running [pmcmc()]
 ##'
 ##' @param burnin Optional integer number of iterations to discard as
-##'   "burn-in". If given then samples \code{1:burnin} will be
+##'   "burn-in". If given then samples `1:burnin` will be
 ##'   excluded from your results. Remember that the first sample
 ##'   represents the starting point of the chain. It is an error if
 ##'   this is not a positive integer or is greater than or equal to
@@ -14,7 +14,7 @@
 ##'   remaining after discarding burnin).
 ##'
 ##' @param thin Optional integer thinning factor. If given, then every
-##'   \code{thin}'th sample is retained (e.g., if \code{thin} is 10
+##'   `thin`'th sample is retained (e.g., if `thin` is 10
 ##'   then we keep samples 1, 11, 21, ...).
 ##'
 ##' @export

--- a/R/predict.R
+++ b/R/predict.R
@@ -1,17 +1,17 @@
-##' Run predictions from the results of \code{\link{pmcmc}}. This
-##' function can also be called by running \code{\link{predict}} on
+##' Run predictions from the results of [pmcmc()]. This
+##' function can also be called by running [predict()] on
 ##' the object, using R's S3 dispatch.
 ##'
 ##' @title Run predictions from PMCMC
 ##'
-##' @param object The results of running \code{\link{pmcmc}} with
-##'   \code{return_state = TRUE} (without this extra information,
+##' @param object The results of running [pmcmc()] with
+##'   `return_state = TRUE` (without this extra information,
 ##'   prediction is not possible)
 ##'
 ##' @param steps A vector of time steps to return predictions for. The
 ##'   first value must be the final value run in your simulation. An
 ##'   error will be thrown if you get this value wrong, look in
-##'   \code{object$predict$step} (or the error message) for the
+##'   `object$predict$step` (or the error message) for the
 ##'   correct value.
 ##'
 ##' @param n_threads The number of threads used in the simulation. If

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,3 +1,4 @@
+burnin
 codecov
 CodeFactor
 discretises
@@ -7,3 +8,4 @@ odin
 pmcmc
 R's
 SMC
+th

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -5,8 +5,8 @@
 \title{Particle filter}
 \description{
 Create a \code{particle_filter} object for running
-  and interacting with a particle filter.  A higher-level
-  interface will be implemented later.
+and interacting with a particle filter.  A higher-level
+interface will be implemented later.
 }
 \examples{
 # A basic SIR model included in the package:
@@ -106,8 +106,8 @@ Create the particle filter
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{data}}{The data set to be used for the particle filter,
-created by \code{\link{particle_filter_data}}. This is essentially
-a \code{\link{data.frame}} with at least columns \code{step_start}
+created by \code{\link[=particle_filter_data]{particle_filter_data()}}. This is essentially
+a \code{\link[=data.frame]{data.frame()}} with at least columns \code{step_start}
 and \code{step_end}, along with any additional data used in the
 \code{compare} function, and additional information about how your
 steps relate to time.}
@@ -128,12 +128,12 @@ is a \code{list} of observed data corresponding to the current
 time's row in the \code{data} object provided here in the
 constructor.  \code{pars} is any additional parameters passed
 through to the comparison function (via the \code{pars}
-argument to \code{$run}).}
+argument to \verb{$run}).}
 
 \item{\code{index}}{An index function. This is used to compute the
 "interesting" indexes of your model. It must be a function of
 one argument, which will be the result of calling the
-\code{$info()} method on your model. It should return a list
+\verb{$info()} method on your model. It should return a list
 with elements \code{run} (indices to return at the end of each
 run, passed through to your compare function) and \code{state}
 (indices to return if saving state). These indices can overlap
@@ -144,10 +144,10 @@ forth.}
 
 \item{\code{initial}}{A function to generate initial conditions. If
 given, then this function must accept 3 arguments: \code{info}
-(the result of calling \code{$info()} as for \code{index}),
+(the result of calling \verb{$info()} as for \code{index}),
 \code{n_particles} (the number of particles that the particle
 filter is using) and \code{pars} (parameters passed in in the
-\code{$run} method via the \code{pars} argument).  It
+\verb{$run} method via the \code{pars} argument).  It
 must return a list, which can have the elements \code{state}
 (initial model state, passed to the particle filter - either a
 vector or a matrix, and overriding the initial conditions
@@ -187,7 +187,7 @@ Run the particle filter}
 the \code{pars} argument to your model, to your \code{compare}
 function, and (if using) to your \code{initial} function. It must
 be an R list (not vector or \code{NULL}) because that is what a
-dust model currently requires on initialisation or \code{$reset} - we
+dust model currently requires on initialisation or \verb{$reset} - we
 may relax this later. You may want to put your observation and
 initial parameters under their own keys (e.g.,
 \code{pars$initial$whatever}), but this is up to you. Extra keys
@@ -195,7 +195,7 @@ are silently ignored by dust models.}
 
 \item{\code{save_history}}{Logical, indicating if the history of all
 particles should be saved. If saving history, then it can be
-queried later with the \code{$history} method on the object.}
+queried later with the \verb{$history} method on the object.}
 }
 \if{html}{\out{</div>}}
 }
@@ -232,8 +232,7 @@ particles.
 Extract the particle trajectories. Requires that
 the model was run with \code{save_history = TRUE}, which does
 incur a performance cost. This method will throw an error if
-the model has not run, or was run without \code{save_history =
-TRUE}. Returns a 3d array with dimensions corresponding to (1)
+the model has not run, or was run without \code{save_history = TRUE}. Returns a 3d array with dimensions corresponding to (1)
 model state, filtered by \code{index$run} if provided, (2)
 particle (following \code{index_particle} if provided), (3)
 time point.

--- a/man/particle_filter_data.Rd
+++ b/man/particle_filter_data.Rd
@@ -7,7 +7,7 @@
 particle_filter_data(data, time, rate, initial_time = NULL)
 }
 \arguments{
-\item{data}{A \code{\link{data.frame}} of data}
+\item{data}{A \code{\link[=data.frame]{data.frame()}} of data}
 
 \item{time}{The name of a column within \code{data} that
 represents your measure of time.  This column must be
@@ -25,10 +25,10 @@ column, minus 1 (i.e., \code{data[[time]] - 1}).}
 }
 \value{
 A data.frame with new columns \code{step_start} and
-  \code{step_end} (required by \code{\link{particle_filter}}),
-  along side all previous data except for the time variable, which
-  is replaced by new \code{<time>_start} and \code{<time>_end}
-  columns.
+\code{step_end} (required by \code{\link{particle_filter}}),
+along side all previous data except for the time variable, which
+is replaced by new \verb{<time>_start} and \verb{<time>_end}
+columns.
 }
 \description{
 Prepare data for use with the \code{\link{particle_filter}}.  This
@@ -43,8 +43,7 @@ We require that the time variable increments in unit steps; this
 may be relaxed in future to even steps, or possibly irregular
 steps, but for now this assumption is required.  We assume that
 the data in the first column is recorded at the end of a period of
-1 time unit.  So if you have in the first column \code{time = 10,
-data = 100} we assume that the model steps from time 9 to to time
+1 time unit.  So if you have in the first column \verb{time = 10, data = 100} we assume that the model steps from time 9 to to time
 10 and at that period the data has value 100.
 }
 \examples{

--- a/man/pmcmc.Rd
+++ b/man/pmcmc.Rd
@@ -25,7 +25,7 @@ process may be restarted from this point for projections.  If
 be selected for each. The default is \code{TRUE}, which will
 cause \code{n_state} * \code{n_steps} of data to be output
 alongside your results. Set this argument to \code{FALSE} to
-save space, or use \code{\link{pmcmc_thin}} after running the
+save space, or use \code{\link[=pmcmc_thin]{pmcmc_thin()}} after running the
 MCMC.}
 
 \item{save_trajectories}{Logical, indicating if the particle
@@ -39,16 +39,15 @@ be selected for each.}
 }
 \value{
 A \code{mcstate_pmcmc} object containing \code{pars}
-  (sampled parameters) and \code{probabilities} (log prior, log
-  likelihood and log posterior values for these
-  probabilities). Two additional fields may be present:
-  \code{state} (if \code{return_state} was \code{TRUE}),
-  containing the final state of a randomly selected particle at
-  the end of the simulation, for each step (will be a matrix with
-  as many rows as your state has variables, and as \code{n_steps +
-  1} columns corresponding to each step). \code{trajectories} will
-  include a 3d array of particle trajectories through the
-  simulation (if \code{return_trajectories} was \code{TRUE}).
+(sampled parameters) and \code{probabilities} (log prior, log
+likelihood and log posterior values for these
+probabilities). Two additional fields may be present:
+\code{state} (if \code{return_state} was \code{TRUE}),
+containing the final state of a randomly selected particle at
+the end of the simulation, for each step (will be a matrix with
+as many rows as your state has variables, and as \code{n_steps + 1} columns corresponding to each step). \code{trajectories} will
+include a 3d array of particle trajectories through the
+simulation (if \code{return_trajectories} was \code{TRUE}).
 }
 \description{
 Run a pmcmc sampler

--- a/man/pmcmc_parameter.Rd
+++ b/man/pmcmc_parameter.Rd
@@ -30,7 +30,7 @@ then \code{prior(initial)} must evaluate to a finite value.}
 Describe a single parameter for use within the pmcmc. Note that
 the name is not set here, but will end up being naturally defined
 when used with \code{\link{pmcmc_parameters}}, which collects
-these together for use with \code{\link{pmcmc}}.
+these together for use with \code{\link[=pmcmc]{pmcmc()}}.
 }
 \examples{
 pmcmc_parameter(0.1)

--- a/man/pmcmc_parameters.Rd
+++ b/man/pmcmc_parameters.Rd
@@ -5,10 +5,10 @@
 \title{pmcmc_parameters}
 \description{
 Construct parameters for use with
-  \code{\link{pmcmc}}. This creates a utility object that is used
-  internally to work with parameters. Most users only need to
-  construct this object, but see the examples for how it can be
-  used.
+\code{\link[=pmcmc]{pmcmc()}}. This creates a utility object that is used
+internally to work with parameters. Most users only need to
+construct this object, but see the examples for how it can be
+used.
 }
 \examples{
 #Construct an object with two parameters:
@@ -60,7 +60,7 @@ Create the pmcmc_parameters object
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{parameters}}{A named \code{list} of
-\code{\link{pmcmc_parameter}} objects, each of which describe a
+\link{pmcmc_parameter} objects, each of which describe a
 single parameter in your model.}
 
 \item{\code{proposal}}{A square proposal distribution corresponding to the
@@ -73,7 +73,7 @@ matrix it must be symmetric and positive definite.}
 
 \item{\code{transform}}{An optional transformation function to apply
 to your parameter vector immediately before passing it to the
-model function. If not given, then \code{\link{as.list}} is
+model function. If not given, then \link{as.list} is
 used, as dust models require this. However, if t you need to
 generate derived parameters from those being actively sampled
 you can do arbitrary transformations here.}
@@ -126,7 +126,7 @@ Compute the prior for a parameter vector
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{theta}}{a parameter vector in the same order as your
-parameters were defined in (see \code{$names()} for that order.
+parameters were defined in (see \verb{$names()} for that order.
 Propose a new parameter vector given a current parameter
 vector. This proposes a new parameter vector given your current
 vector and the variance-covariance matrix of your proposal
@@ -148,7 +148,7 @@ parameters until they lie within \code{min}:\code{max}.}
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{theta}}{a parameter vector in the same order as your
-parameters were defined in (see \code{$names()} for that order.
+parameters were defined in (see \verb{$names()} for that order.
 Apply the model transformation function to a parameter vector.}
 }
 \if{html}{\out{</div>}}
@@ -166,7 +166,7 @@ Apply the model transformation function to a parameter vector.}
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{theta}}{a parameter vector in the same order as your
-parameters were defined in (see \code{$names()} for that order.}
+parameters were defined in (see \verb{$names()} for that order.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/pmcmc_predict.Rd
+++ b/man/pmcmc_predict.Rd
@@ -13,7 +13,7 @@ pmcmc_predict(
 )
 }
 \arguments{
-\item{object}{The results of running \code{\link{pmcmc}} with
+\item{object}{The results of running \code{\link[=pmcmc]{pmcmc()}} with
 \code{return_state = TRUE} (without this extra information,
 prediction is not possible)}
 
@@ -35,7 +35,7 @@ this will be removed, or the interface altered, in a future
 version.}
 }
 \description{
-Run predictions from the results of \code{\link{pmcmc}}. This
-function can also be called by running \code{\link{predict}} on
+Run predictions from the results of \code{\link[=pmcmc]{pmcmc()}}. This
+function can also be called by running \code{\link[=predict]{predict()}} on
 the object, using R's S3 dispatch.
 }

--- a/man/pmcmc_thin.Rd
+++ b/man/pmcmc_thin.Rd
@@ -7,7 +7,7 @@
 pmcmc_thin(object, burnin = NULL, thin = NULL)
 }
 \arguments{
-\item{object}{Results of running \code{\link{pmcmc}}}
+\item{object}{Results of running \code{\link[=pmcmc]{pmcmc()}}}
 
 \item{burnin}{Optional integer number of iterations to discard as
 "burn-in". If given then samples \code{1:burnin} will be
@@ -22,7 +22,7 @@ remaining after discarding burnin).}
 then we keep samples 1, 11, 21, ...).}
 }
 \description{
-Thin results of running \code{\link{pmcmc}}. This function may be
-useful before using \code{\link{pmcmc_predict}}, or before saving
+Thin results of running \code{\link[=pmcmc]{pmcmc()}}. This function may be
+useful before using \code{\link[=pmcmc_predict]{pmcmc_predict()}}, or before saving
 pmcmc output to disk.
 }


### PR DESCRIPTION
Noisy diff with no features - uses the roxygen markdown syntax for inline code and cross-links

Fixes #38 