### PR TITLE
i46: Use new flexible dust seeding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     packages:
       - libnode-dev
 r_github_packages:
-  - mrc-ide/dust
+  - mrc-ide/dust@i87-rng-seed
 r_packages:
   - covr
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     packages:
       - libnode-dev
 r_github_packages:
-  - mrc-ide/dust@i87-rng-seed
+  - mrc-ide/dust
 r_packages:
   - covr
 after_success:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),
@@ -21,7 +21,7 @@ URL: https://github.com/mrc-ide/mcstate
 BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
-    dust (>= 0.4.4)
+    dust (>= 0.4.5)
 Suggests:
     brio,
     coda,

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -376,7 +376,7 @@ particle_filter <- R6::R6Class(
       ## TODO: this name is terrible.
       list(n_threads = private$last_model$n_threads(),
            index = private$last_index_state,
-           seed = private$last_model$rng_state(TRUE),
+           seed = private$last_model$rng_state(first_only = TRUE),
            step = c(private$data$step_start[[1]], private$data$step_end),
            rate = attr(private$data, "rate", exact = TRUE))
     }

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -155,11 +155,14 @@ particle_filter <- R6::R6Class(
     ##' number of cores available to the machine.
     ##'
     ##' @param seed Seed for the random number generator on initial
-    ##' creation; must be a positive integer. Note that this is unrelated
-    ##' to R's random number generator (see [`dust`]).
+    ##' creation. Can be `NULL` (to initialise using R's random number
+    ##' generator), a positive integer, or a raw vector - see [`dust::dust`]
+    ##' and [`dust::dust_rng`] for more details. Note that the random number
+    ##' stream is unrelated from R's random number generator, except for
+    ##' initialisation with `seed = NULL`.
     initialize = function(data, model, n_particles, compare,
                           index = NULL, initial = NULL,
-                          n_threads = 1L, seed = 1L) {
+                          n_threads = 1L, seed = NULL) {
       if (!is_dust_generator(model)) {
         stop("'model' must be a dust_generator")
       }
@@ -181,7 +184,7 @@ particle_filter <- R6::R6Class(
 
       self$n_particles <- assert_scalar_positive_integer(n_particles)
       private$n_threads <- assert_scalar_positive_integer(n_threads)
-      private$seed <- assert_scalar_positive_integer(seed)
+      private$seed <- seed
 
       lockBinding("model", self)
       lockBinding("n_particles", self)
@@ -373,6 +376,7 @@ particle_filter <- R6::R6Class(
       ## TODO: this name is terrible.
       list(n_threads = private$last_model$n_threads(),
            index = private$last_index_state,
+           seed = private$last_model$rng_state(TRUE),
            step = c(private$data$step_start[[1]], private$data$step_end),
            rate = attr(private$data, "rate", exact = TRUE))
     }

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -128,11 +128,7 @@ pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
   probabilities <- set_colnames(list_to_matrix(history_probabilities$get()),
                        c("log_prior", "log_likelihood", "log_posterior"))
 
-  info <- predict <- state <- trajectories <- NULL
-
-  if (save_state || save_trajectories) {
-    info <- filter$predict_info()
-  }
+  predict <- state <- trajectories <- NULL
 
   if (save_state) {
     state <- t(list_to_matrix(history_state$get()))
@@ -141,6 +137,9 @@ pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
     ## it's all we want; this is a bit of a hack but it works for now
     ## at least.
     transform <- pars[[".__enclos_env__"]]$private$transform
+
+    ## Information about how the particle filter was configured:
+    info <- filter$predict_info()
 
     ## This information is required in order to run predictions but
     ## adds a significant space overhead to the saved data (model is
@@ -156,6 +155,7 @@ pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
   }
 
   if (save_trajectories) {
+    info <- filter$predict_info()
     ## Permute trajectories from [state x mcmc x particle] to
     ## [state x particle x mcmc] so that they match the ones that we
     ## will generate with predict

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -128,7 +128,12 @@ pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
   probabilities <- set_colnames(list_to_matrix(history_probabilities$get()),
                        c("log_prior", "log_likelihood", "log_posterior"))
 
-  predict <- state <- trajectories <- NULL
+  info <- predict <- state <- trajectories <- NULL
+
+  if (save_state || save_trajectories) {
+    info <- filter$predict_info()
+  }
+
   if (save_state) {
     state <- t(list_to_matrix(history_state$get()))
 
@@ -136,9 +141,6 @@ pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
     ## it's all we want; this is a bit of a hack but it works for now
     ## at least.
     transform <- pars[[".__enclos_env__"]]$private$transform
-
-    ## Information about how the particle filter was configured:
-    info <- filter$predict_info()
 
     ## This information is required in order to run predictions but
     ## adds a significant space overhead to the saved data (model is
@@ -149,10 +151,11 @@ pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
                     n_threads = info$n_threads,
                     index = info$index,
                     rate = info$rate,
+                    seed = info$seed,
                     step = last(info$step))
   }
+
   if (save_trajectories) {
-    info <- filter$predict_info()
     ## Permute trajectories from [state x mcmc x particle] to
     ## [state x particle x mcmc] so that they match the ones that we
     ## will generate with predict

--- a/R/predict.R
+++ b/R/predict.R
@@ -18,16 +18,24 @@
 ##'   not given, we default to the value used in the particle filter
 ##'   that was used in the pmcmc.
 ##'
-##' @param seed The random number seed - a positive integer. Note that
-##'   this will be removed, or the interface altered, in a future
-##'   version.
+##' @param seed The random number seed (see [`particle_filter`]). The
+##'   default value of `NULL` will seed the dust random number
+##'   generator from R's random number generator. However, you can
+##'   pick up from the same RNG stream used in the simulation if you
+##'   pass in `seed = object$predict$seed`. However, do not do this if
+##'   you are gong to run `pmcmc_predict()` multiple times the result
+##'   will be identical. If you do want to call predict with this
+##'   state multiple times you should call
+##'   [dust::dust_rng_state_advance()] with a `times` argument of `i +
+##'   1` for the `i`'th usage (i.e., advance twice for the first
+##'   usage, three times for the 2nd, etc).
 ##'
 ##' @param prepend_trajectories Prepend trajectories from the particle
 ##'   filter to the predictions created here.
 ##'
 ##' @export
 pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
-                          n_threads = NULL, seed = 1L) {
+                          n_threads = NULL, seed = NULL) {
   if (is.null(object$predict)) {
     stop("mcmc was run with return_state = FALSE, can't predict")
   }
@@ -47,6 +55,7 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   index <- object$predict$index
   model <- object$predict$model
   n_threads <- n_threads %||% object$predict$n_threads
+  seed <- seed %||% object$predict$seed
 
   y <- dust::dust_simulate(model, steps, data, state, index, n_threads, seed)
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -26,9 +26,9 @@
 ##'   you are gong to run `pmcmc_predict()` multiple times the result
 ##'   will be identical. If you do want to call predict with this
 ##'   state multiple times you should call
-##'   [dust::dust_rng_state_advance()] with a `times` argument of `i +
-##'   1` for the `i`'th usage (i.e., advance twice for the first
-##'   usage, three times for the 2nd, etc).
+##'   [dust::dust_rng_state_long_jump()] with a `times` argument of `i`
+##'   for the `i`'th usage (i.e., once for the first usage,
+##'   two times for the 2nd, etc).
 ##'
 ##' @param prepend_trajectories Prepend trajectories from the particle
 ##'   filter to the predictions created here.
@@ -55,7 +55,6 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   index <- object$predict$index
   model <- object$predict$model
   n_threads <- n_threads %||% object$predict$n_threads
-  seed <- seed %||% object$predict$seed
 
   y <- dust::dust_simulate(model, steps, data, state, index, n_threads, seed)
 

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -98,7 +98,7 @@ Create the particle filter
   index = NULL,
   initial = NULL,
   n_threads = 1L,
-  seed = 1L
+  seed = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -165,8 +165,11 @@ simulation. Defaults to 1, and should not be set higher than the
 number of cores available to the machine.}
 
 \item{\code{seed}}{Seed for the random number generator on initial
-creation; must be a positive integer. Note that this is unrelated
-to R's random number generator (see \code{\link{dust}}).
+creation. Can be \code{NULL} (to initialise using R's random number
+generator), a positive integer, or a raw vector - see \code{\link[dust:dust]{dust::dust}}
+and \code{\link[dust:dust_rng]{dust::dust_rng}} for more details. Note that the random number
+stream is unrelated from R's random number generator, except for
+initialisation with \code{seed = NULL}.
 Run the particle filter}
 }
 \if{html}{\out{</div>}}

--- a/man/pmcmc_predict.Rd
+++ b/man/pmcmc_predict.Rd
@@ -9,7 +9,7 @@ pmcmc_predict(
   steps,
   prepend_trajectories = FALSE,
   n_threads = NULL,
-  seed = 1L
+  seed = NULL
 )
 }
 \arguments{
@@ -30,9 +30,16 @@ filter to the predictions created here.}
 not given, we default to the value used in the particle filter
 that was used in the pmcmc.}
 
-\item{seed}{The random number seed - a positive integer. Note that
-this will be removed, or the interface altered, in a future
-version.}
+\item{seed}{The random number seed (see \code{\link{particle_filter}}). The
+default value of \code{NULL} will seed the dust random number
+generator from R's random number generator. However, you can
+pick up from the same RNG stream used in the simulation if you
+pass in \code{seed = object$predict$seed}. However, do not do this if
+you are gong to run \code{pmcmc_predict()} multiple times the result
+will be identical. If you do want to call predict with this
+state multiple times you should call
+\code{\link[dust:dust_rng_state_advance]{dust::dust_rng_state_advance()}} with a \code{times} argument of \code{i + 1} for the \code{i}'th usage (i.e., advance twice for the first
+usage, three times for the 2nd, etc).}
 }
 \description{
 Run predictions from the results of \code{\link[=pmcmc]{pmcmc()}}. This

--- a/man/pmcmc_predict.Rd
+++ b/man/pmcmc_predict.Rd
@@ -38,8 +38,9 @@ pass in \code{seed = object$predict$seed}. However, do not do this if
 you are gong to run \code{pmcmc_predict()} multiple times the result
 will be identical. If you do want to call predict with this
 state multiple times you should call
-\code{\link[dust:dust_rng_state_advance]{dust::dust_rng_state_advance()}} with a \code{times} argument of \code{i + 1} for the \code{i}'th usage (i.e., advance twice for the first
-usage, three times for the 2nd, etc).}
+\code{\link[dust:dust_rng_state_long_jump]{dust::dust_rng_state_long_jump()}} with a \code{times} argument of \code{i}
+for the \code{i}'th usage (i.e., once for the first usage,
+two times for the 2nd, etc).}
 }
 \description{
 Run predictions from the results of \code{\link[=pmcmc]{pmcmc()}}. This

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -130,3 +130,8 @@ example_sir_pmcmc <- function() {
   }
   test_cache$example_sir_pmcmc
 }
+
+
+r6_private <- function(x) {
+  x[[".__enclos_env__"]]$private
+}

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -174,9 +174,6 @@ test_that("control filter", {
     particle_filter$new(dat$data, dat$model, 0, dat$compare),
     "'n_particles' must be at least 1")
   expect_error(
-    particle_filter$new(dat$data, dat$model, 1, dat$compare, seed = -1),
-    "'seed' must be at least 1")
-  expect_error(
     particle_filter$new(dat$data, dat$model, 1, dat$compare, n_threads = -1),
     "'n_threads' must be at least 1")
 })
@@ -369,13 +366,13 @@ test_that("Variable initial starting point of the simulation", {
   }
 
   p <- particle_filter$new(data, dat$model, n_particles, compare,
-                           index = dat$index, initial = initial)
+                           index = dat$index, initial = initial, seed = 1L)
   pars <- list(I0 = 10, step_mean = 20, step_offset = 400)
   set.seed(1)
   ll <- p$run(pars, save_history = TRUE)
   expect_equal(ll, 0)
 
-  mod <- p$model$new(list(), step = 0, n_particles = n_particles)
+  mod <- p$model$new(list(), step = 0, n_particles = n_particles, seed = 1L)
   tmp <- initial(NULL, n_particles, pars)
   mod$set_state(tmp$state, tmp$step)
   expect_equal(p$history()[, , 1], mod$state()[1:3, ])

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -149,7 +149,7 @@ test_that("run pmcmc with the particle filter and retain history", {
 })
 
 
-test_that("collecting state from model advances the RNG", {
+test_that("collecting state from model yields an RNG state", {
   dat <- example_sir()
   n_particles <- 30
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
@@ -157,23 +157,21 @@ test_that("collecting state from model advances the RNG", {
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index, seed = 1L)
   p3 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
-                            index = dat$index, seed = 1L)
+                            index = dat$index, seed = 2L)
 
   set.seed(1)
   results1 <- pmcmc(dat$pars, p1, 5, FALSE, FALSE)
   set.seed(1)
-  results2 <- pmcmc(dat$pars, p2, 5, FALSE, FALSE)
+  results2 <- pmcmc(dat$pars, p2, 5, TRUE, FALSE)
   set.seed(1)
   results3 <- pmcmc(dat$pars, p3, 5, TRUE, FALSE)
 
   expect_identical(
-    r6_private(p1)$last_model$rng_state(FALSE),
-    r6_private(p2)$last_model$rng_state(FALSE))
-  expect_false(identical(
-    r6_private(p1)$last_model$rng_state(FALSE),
-    r6_private(p3)$last_model$rng_state(FALSE)))
-  invisible(r6_private(p1)$last_model$rng_state(TRUE))
+    r6_private(p1)$last_model$rng_state(),
+    r6_private(p2)$last_model$rng_state())
   expect_identical(
-    r6_private(p1)$last_model$rng_state(FALSE),
-    r6_private(p3)$last_model$rng_state(FALSE))
+    results2$predict$seed,
+    r6_private(p1)$last_model$rng_state()[1:32])
+  expect_false(
+    identical(results2$predict$seed, results3$predict$seed))
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -32,10 +32,10 @@ test_that("Can rehydrate mcmc results and predict", {
   results <- example_sir_pmcmc()$pmcmc
 
   steps <- seq(results$predict$step, by = 4, length.out = 26)
-  y1 <- pmcmc_predict(results, steps)
+  y1 <- pmcmc_predict(results, steps, seed = 1L)
 
   results <- unserialize(serialize(results, NULL))
-  expect_identical(pmcmc_predict(results, steps), y1)
+  expect_identical(pmcmc_predict(results, steps, seed = 1L), y1)
 })
 
 
@@ -43,8 +43,8 @@ test_that("Can combine runs with predictions", {
   results <- example_sir_pmcmc()$pmcmc
 
   steps <- seq(results$predict$step, by = 4, length.out = 26)
-  y1 <- pmcmc_predict(results, steps, prepend_trajectories = TRUE)
-  y2 <- pmcmc_predict(results, steps)
+  y1 <- pmcmc_predict(results, steps, prepend_trajectories = TRUE, seed = 1L)
+  y2 <- pmcmc_predict(results, steps, seed = 1L)
 
   expect_is(y1, "mcstate_trajectories")
   expect_equal(y1$rate, 4)
@@ -97,6 +97,19 @@ test_that("S3 method works as expected", {
   set.seed(1)
   y2 <- pmcmc_predict(results, steps)
   expect_identical(y1, y2)
+})
+
+
+test_that("seed = NULL respects R's seed", {
+  results <- example_sir_pmcmc()$pmcmc
+  steps <- seq(results$predict$step, by = 4, length.out = 26)
+  set.seed(1)
+  y1 <- pmcmc_predict(results, steps)
+  y2 <- pmcmc_predict(results, steps)
+  set.seed(1)
+  y3 <- pmcmc_predict(results, steps)
+  expect_false(identical(y1, y2))
+  expect_identical(y1, y3)
 })
 
 


### PR DESCRIPTION
This PR makes mcstate's seeding more flexible, using the new approach in dust. The default value for seed is `NULL` and it's possible to continue a stream of random numbers in `dust_simulate` using the final state of the RNG which is saved.

* should we save just the first 32 bytes of state into the object? This will be much smaller and also faster to jump. The state is unlikely to compress well on serialisation so for 1k particles we will have 32Kb of data.
* we advance the state of the rng at the save point which guarantees the states are decoupled. But would it make more sense to jump the state of saved state? This means we're not really continuing but are definitely uncorrelated and might simplify use in the parallel case

Depends on mrc-ide/dust#88 and should not be merged until that is (and the travis branch pin removed).

Fixes #46 