### PR TITLE
i58: multiple chains

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     brio,
     coda,
     decor,
+    mockery,
     mvtnorm,
     testthat,
     tibble,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -47,6 +47,11 @@
 ##' @param progress Logical, indicating if a progress bar should be
 ##'   displayed, using [`progress::progress_bar`].
 ##'
+##' @param n_chains Optional integer, indicating the number of chains
+##'   to run. If more than one then we run a series of chains and
+##'   merge them with [pmcmc_combine()]. Chains are run in series,
+##'   with the same filter.
+##'
 ##' @return A `mcstate_pmcmc` object containing `pars`
 ##'   (sampled parameters) and `probabilities` (log prior, log
 ##'   likelihood and log posterior values for these
@@ -61,13 +66,32 @@
 ##'
 ##' @export
 pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
-                  save_trajectories = FALSE, progress = FALSE) {
+                  save_trajectories = FALSE, progress = FALSE,
+                  n_chains = 1) {
   assert_is(pars, "pmcmc_parameters")
   assert_is(filter, "particle_filter")
   assert_scalar_positive_integer(n_steps)
   assert_scalar_logical(save_state)
   assert_scalar_logical(save_trajectories)
+  assert_scalar_positive_integer(n_chains)
 
+  if (n_chains == 1) {
+    pmcmc1(pars, filter, n_steps, save_state, save_trajectories, progress)
+  } else {
+    samples <- vector("list", n_chains)
+    for (i in seq_along(samples)) {
+      if (progress) {
+        message(sprintf("Running chain %d / %d", i, n_chains))
+      }
+      samples[[i]] <-
+        pmcmc1(pars, filter, n_steps, save_state, save_trajectories, progress)
+    }
+    pmcmc_combine(samples = samples)
+  }
+}
+
+pmcmc1 <- function(pars, filter, n_steps, save_state, save_trajectories,
+                   progress) {
   n_particles <- filter$n_particles
 
   history_pars <- history_collector(n_steps)

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -76,22 +76,25 @@ pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
   assert_scalar_positive_integer(n_chains)
 
   if (n_chains == 1) {
-    pmcmc1(pars, filter, n_steps, save_state, save_trajectories, progress)
+    pmcmc_single_chain(pars, filter, n_steps,
+                       save_state, save_trajectories, progress)
   } else {
     samples <- vector("list", n_chains)
     for (i in seq_along(samples)) {
       if (progress) {
         message(sprintf("Running chain %d / %d", i, n_chains))
       }
-      samples[[i]] <-
-        pmcmc1(pars, filter, n_steps, save_state, save_trajectories, progress)
+      samples[[i]] <- pmcmc_single_chain(pars, filter, n_steps,
+                                         save_state, save_trajectories,
+                                         progress)
     }
     pmcmc_combine(samples = samples)
   }
 }
 
-pmcmc1 <- function(pars, filter, n_steps, save_state, save_trajectories,
-                   progress) {
+pmcmc_single_chain <- function(pars, filter, n_steps,
+                               save_state, save_trajectories,
+                               progress) {
   n_particles <- filter$n_particles
 
   history_pars <- history_collector(n_steps)

--- a/man/pmcmc.Rd
+++ b/man/pmcmc.Rd
@@ -10,7 +10,8 @@ pmcmc(
   n_steps,
   save_state = TRUE,
   save_trajectories = FALSE,
-  progress = FALSE
+  progress = FALSE,
+  n_chains = 1
 )
 }
 \arguments{
@@ -46,6 +47,11 @@ be selected for each.}
 
 \item{progress}{Logical, indicating if a progress bar should be
 displayed, using \code{\link[progress:progress_bar]{progress::progress_bar}}.}
+
+\item{n_chains}{Optional integer, indicating the number of chains
+to run. If more than one then we run a series of chains and
+merge them with \code{\link[=pmcmc_combine]{pmcmc_combine()}}. Chains are run in series,
+with the same filter.}
 }
 \value{
 A \code{mcstate_pmcmc} object containing \code{pars}

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -223,14 +223,15 @@ test_that("All arguments forwarded to multiple chains", {
     pmcmc(dat$pars, dat$filter, 1000, FALSE, FALSE),
     pmcmc(dat$pars, dat$filter, 1000, FALSE, FALSE))
 
-  mock_pmcmc1 <- mockery::mock(res[[1]], res[[1]], res[[2]], res[[3]])
-  with_mock("mcstate::pmcmc1" = mock_pmcmc1, {
+  mock_pmcmc_single_chain <- mockery::mock(
+    res[[1]], res[[1]], res[[2]], res[[3]])
+  with_mock("mcstate::pmcmc_single_chain" = mock_pmcmc_single_chain, {
     ans1 <- pmcmc(dat$pars, dat$filter, 1000, FALSE, FALSE, FALSE)
     ans2 <- pmcmc(dat$pars, dat$filter, 1000, FALSE, FALSE, FALSE, n_chains = 3)
   })
 
-  mockery::expect_called(mock_pmcmc1, 4)
-  args <- mockery::mock_args(mock_pmcmc1)
+  mockery::expect_called(mock_pmcmc_single_chain, 4)
+  args <- mockery::mock_args(mock_pmcmc_single_chain)
   expect_equal(args[[1]],
                list(dat$pars, dat$filter, 1000, FALSE, FALSE, FALSE))
   expect_equal(args[[2]],

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -187,3 +187,29 @@ test_that("running pmcmc with progress = TRUE prints messages", {
     pmcmc(dat$pars, dat$filter, 1000, FALSE, FALSE, progress = TRUE),
     "Finished 1000 steps in ")
 })
+
+
+test_that("run multiple chains", {
+  dat <- example_uniform()
+
+  set.seed(1)
+  res1 <- pmcmc(dat$pars, dat$filter, 100, FALSE, FALSE, n_chains = 1)
+  expect_s3_class(res1, "mcstate_pmcmc")
+  expect_null(res1$chain)
+
+  set.seed(1)
+  res3 <- pmcmc(dat$pars, dat$filter, 100, FALSE, FALSE, n_chains = 3)
+  expect_s3_class(res3, "mcstate_pmcmc")
+  expect_equal(res3$chain, rep(1:3, each = 101))
+
+  expect_equal(res1$pars, res3$pars[1:101, ])
+})
+
+
+test_that("progress in multiple chains", {
+  dat <- example_uniform()
+  expect_message(
+    pmcmc(dat$pars, dat$filter, 100, FALSE, FALSE, progress = TRUE,
+          n_chains = 3),
+    "Running chain 2 / 3")
+})


### PR DESCRIPTION
Simple support for multiple chains.

As used in the ONS task, seems generally useful.  We'll likely need a slightly different interface to support #51 though.

Fixes #58 
