### PR TITLE
i56: parameter name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.6
+Version: 0.2.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc_parameters.R
+++ b/R/pmcmc_parameters.R
@@ -5,6 +5,8 @@
 ##'
 ##' @title Describe single pmcmc parameter
 ##'
+##' @param name Name for the parameter (a string)
+##'
 ##' @param initial Initial value for the parameter
 ##'
 ##' @param min Optional minimum value for the parameter (otherwise
@@ -26,9 +28,10 @@
 ##'
 ##' @export
 ##' @examples
-##' pmcmc_parameter(0.1)
-pmcmc_parameter <- function(initial, min = -Inf, max = Inf, discrete = FALSE,
-                            prior = NULL) {
+##' pmcmc_parameter("a", 0.1)
+pmcmc_parameter <- function(name, initial, min = -Inf, max = Inf,
+                            discrete = FALSE, prior = NULL) {
+  assert_scalar_character(name)
   assert_scalar_logical(discrete)
 
   if (initial < min) {
@@ -45,15 +48,18 @@ pmcmc_parameter <- function(initial, min = -Inf, max = Inf, discrete = FALSE,
     value <- tryCatch(
       prior(initial),
       error = function(e)
-        stop("Failed to evalute your prior function on initial value: ",
-             e$message))
+        stop(sprintf(
+          "Prior function for '%s' failed to evaluate initial value: %s",
+          name, e$message)))
     if (!is.finite(value)) {
-      stop("Your prior function returned an non-finite value on initial value")
+      stop(sprintf(
+        "Prior function for '%s' returned a non-finite value on initial value",
+        name))
     }
   }
 
-  ret <- list(initial = initial, min = min, max = max, discrete = discrete,
-              prior = prior %||% function(p) 0)
+  ret <- list(name = name, initial = initial, min = min, max = max,
+              discrete = discrete, prior = prior %||% function(p) 0)
   class(ret) <- "pmcmc_parameter"
   ret
 }
@@ -71,9 +77,9 @@ pmcmc_parameter <- function(initial, min = -Inf, max = Inf, discrete = FALSE,
 ##' @examples
 ##' #Construct an object with two parameters:
 ##' pars <- mcstate::pmcmc_parameters$new(
-##'   list(a = mcstate::pmcmc_parameter(0.1, min = 0, max = 1,
-##'                                     prior = function(a) log(a)),
-##'        b = mcstate::pmcmc_parameter(0, prior = dnorm)),
+##'   list(mcstate::pmcmc_parameter("a", 0.1, min = 0, max = 1,
+##'                                 prior = function(a) log(a)),
+##'        mcstate::pmcmc_parameter("b", 0, prior = dnorm)),
 ##'   matrix(c(1, 0.5, 0.5, 2), 2, 2))
 ##'
 ##' # Initial parameters
@@ -108,9 +114,10 @@ pmcmc_parameters <- R6::R6Class(
   public = list(
     ##' @description Create the pmcmc_parameters object
     ##'
-    ##' @param parameters A named `list` of
+    ##' @param parameters A `list` of
     ##' [pmcmc_parameter] objects, each of which describe a
-    ##' single parameter in your model.
+    ##' single parameter in your model. Any names on the `parameters` list
+    ##' are ignored, and the `$name` element of each parameter is used.
     ##'
     ##' @param proposal A square proposal distribution corresponding to the
     ##' variance-covariance matrix of a multivariate gaussian distribution
@@ -127,7 +134,6 @@ pmcmc_parameters <- R6::R6Class(
     ##' generate derived parameters from those being actively sampled
     ##' you can do arbitrary transformations here.
     initialize = function(parameters, proposal, transform = NULL) {
-      assert_named(parameters, TRUE)
       assert_is(parameters, "list")
       if (length(parameters) == 0) {
         stop("At least one parameter is required")
@@ -135,6 +141,11 @@ pmcmc_parameters <- R6::R6Class(
       ok <- vlapply(parameters, inherits, "pmcmc_parameter")
       if (!all(ok)) {
         stop("Expected all elements of '...' to be 'pmcmc_parameter' objects")
+      }
+      names(parameters) <- vcapply(parameters, "[[", "name")
+      dups <- names(parameters)[duplicated(names(parameters))]
+      if (length(dups) > 0L) {
+        stop("Duplicate parmeter names are not allowed")
       }
 
       if (is.null(transform)) {

--- a/R/pmcmc_parameters.R
+++ b/R/pmcmc_parameters.R
@@ -116,8 +116,9 @@ pmcmc_parameters <- R6::R6Class(
     ##'
     ##' @param parameters A `list` of
     ##' [pmcmc_parameter] objects, each of which describe a
-    ##' single parameter in your model. Any names on the `parameters` list
-    ##' are ignored, and the `$name` element of each parameter is used.
+    ##' single parameter in your model. If `parameters` is named, then
+    ##' these names must match the `$name` element of each parameter is
+    ##' used (this is verified).
     ##'
     ##' @param proposal A square proposal distribution corresponding to the
     ##' variance-covariance matrix of a multivariate gaussian distribution
@@ -142,11 +143,16 @@ pmcmc_parameters <- R6::R6Class(
       if (!all(ok)) {
         stop("Expected all elements of '...' to be 'pmcmc_parameter' objects")
       }
-      names(parameters) <- vcapply(parameters, "[[", "name")
-      dups <- names(parameters)[duplicated(names(parameters))]
+      nms <- vcapply(parameters, "[[", "name", USE.NAMES = FALSE)
+      dups <- nms[duplicated(nms)]
       if (length(dups) > 0L) {
-        stop("Duplicate parmeter names are not allowed")
+        stop("Duplicate parameter names: ",
+             paste(squote(unique(dups)), collapse = ", "))
       }
+      if (!is.null(names(parameters)) && !identical(nms, names(parameters))) {
+        stop("'parameters' is named, but the names do not match parameters")
+      }
+      names(parameters) <- nms
 
       if (is.null(transform)) {
         transform <- as.list

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,6 +13,11 @@ vnapply <- function(x, fun, ...) {
 }
 
 
+vcapply <- function(x, fun, ...) {
+  vapply(x, fun, character(1), ...)
+}
+
+
 list_to_numeric <- function(x) {
   vnapply(x, identity)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,8 @@ df_to_list_of_lists <- function(x) {
 all_or_none <- function(x) {
   all(x) || !any(x)
 }
+
+
+squote <- function(x) {
+  sprintf("'%s'", x)
+}

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -39,6 +39,14 @@ assert_logical <- function(x, name = deparse(substitute(x))) {
 }
 
 
+assert_character <- function(x, name = deparse(substitute(x))) {
+  if (!(is.character(x))) {
+    stop(sprintf("'%s' must be a character", name), call. = FALSE)
+  }
+  invisible(x)
+}
+
+
 assert_strictly_increasing <- function(x, name = deparse(substitute(x))) {
   if (any(diff(x) <= 0)) {
     stop(sprintf("'%s' must be strictly increasing", name), call. = FALSE)
@@ -70,5 +78,13 @@ assert_scalar_logical <- function(x, name = deparse(substitute(x))) {
   force(name)
   assert_scalar(x, name)
   assert_logical(x, name)
+  invisible(x)
+}
+
+
+assert_scalar_character <- function(x, name = deparse(substitute(x))) {
+  force(name)
+  assert_scalar(x, name)
+  assert_character(x, name)
   invisible(x)
 }

--- a/man/pmcmc_parameter.Rd
+++ b/man/pmcmc_parameter.Rd
@@ -4,9 +4,18 @@
 \alias{pmcmc_parameter}
 \title{Describe single pmcmc parameter}
 \usage{
-pmcmc_parameter(initial, min = -Inf, max = Inf, discrete = FALSE, prior = NULL)
+pmcmc_parameter(
+  name,
+  initial,
+  min = -Inf,
+  max = Inf,
+  discrete = FALSE,
+  prior = NULL
+)
 }
 \arguments{
+\item{name}{Name for the parameter (a string)}
+
 \item{initial}{Initial value for the parameter}
 
 \item{min}{Optional minimum value for the parameter (otherwise
@@ -33,5 +42,5 @@ when used with \code{\link{pmcmc_parameters}}, which collects
 these together for use with \code{\link[=pmcmc]{pmcmc()}}.
 }
 \examples{
-pmcmc_parameter(0.1)
+pmcmc_parameter("a", 0.1)
 }

--- a/man/pmcmc_parameters.Rd
+++ b/man/pmcmc_parameters.Rd
@@ -13,9 +13,9 @@ used.
 \examples{
 #Construct an object with two parameters:
 pars <- mcstate::pmcmc_parameters$new(
-  list(a = mcstate::pmcmc_parameter(0.1, min = 0, max = 1,
-                                    prior = function(a) log(a)),
-       b = mcstate::pmcmc_parameter(0, prior = dnorm)),
+  list(mcstate::pmcmc_parameter("a", 0.1, min = 0, max = 1,
+                                prior = function(a) log(a)),
+       mcstate::pmcmc_parameter("b", 0, prior = dnorm)),
   matrix(c(1, 0.5, 0.5, 2), 2, 2))
 
 # Initial parameters
@@ -59,9 +59,10 @@ Create the pmcmc_parameters object
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{parameters}}{A named \code{list} of
+\item{\code{parameters}}{A \code{list} of
 \link{pmcmc_parameter} objects, each of which describe a
-single parameter in your model.}
+single parameter in your model. Any names on the \code{parameters} list
+are ignored, and the \verb{$name} element of each parameter is used.}
 
 \item{\code{proposal}}{A square proposal distribution corresponding to the
 variance-covariance matrix of a multivariate gaussian distribution

--- a/man/pmcmc_parameters.Rd
+++ b/man/pmcmc_parameters.Rd
@@ -61,8 +61,9 @@ Create the pmcmc_parameters object
 \describe{
 \item{\code{parameters}}{A \code{list} of
 \link{pmcmc_parameter} objects, each of which describe a
-single parameter in your model. Any names on the \code{parameters} list
-are ignored, and the \verb{$name} element of each parameter is used.}
+single parameter in your model. If \code{parameters} is named, then
+these names must match the \verb{$name} element of each parameter is
+used (this is verified).}
 
 \item{\code{proposal}}{A square proposal distribution corresponding to the
 variance-covariance matrix of a multivariate gaussian distribution

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -39,10 +39,10 @@ example_sir <- function() {
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
 
   pars <- pmcmc_parameters$new(
-    list(beta = pmcmc_parameter(0.2, min = 0, max = 1,
-                                prior = function(p) log(1e-10)),
-         gamma = pmcmc_parameter(0.1, min = 0, max = 1,
-                                 prior = function(p) log(1e-10))),
+    list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
+                         prior = function(p) log(1e-10)),
+         pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
+                         prior = function(p) log(1e-10))),
     proposal = proposal_kernel)
 
   list(model = model, compare = compare, y0 = y0,
@@ -67,8 +67,8 @@ example_uniform <- function(proposal_kernel = NULL) {
   }
 
   pars <- pmcmc_parameters$new(
-    list(a = pmcmc_parameter(0.5, min = 0, max = 1),
-         b = pmcmc_parameter(0.5, min = 0, max = 1)),
+    list(pmcmc_parameter("a", 0.5, min = 0, max = 1),
+         pmcmc_parameter("b", 0.5, min = 0, max = 1)),
     proposal = proposal_kernel)
 
   list(target = target, filter = filter, pars = pars)
@@ -88,8 +88,8 @@ example_mvnorm <- function() {
 
   proposal_kernel <- diag(2)
   pars <- pmcmc_parameters$new(
-    list(a = pmcmc_parameter(0, min = -100, max = 100),
-         b = pmcmc_parameter(0, min = -100, max = 100)),
+    list(pmcmc_parameter("a", 0, min = -100, max = 100),
+         pmcmc_parameter("b", 0, min = -100, max = 100)),
     proposal = proposal_kernel)
 
   list(target = target, filter = filter, pars = pars)

--- a/tests/testthat/test-pmcmc-parameters.R
+++ b/tests/testthat/test-pmcmc-parameters.R
@@ -206,3 +206,33 @@ test_that("can summarise parameters", {
     p$summary(),
     data_frame(name = c("beta", "gamma"), min = 0, max = 1, discrete = FALSE))
 })
+
+
+test_that("duplicate parameter names are rejected", {
+  expect_error(
+    pmcmc_parameters$new(
+      list(pmcmc_parameter("a", 0.2), pmcmc_parameter("a", 0.1)),
+      matrix(1, 2, 2)),
+    "Duplicate parameter names: 'a'")
+  expect_error(
+    pmcmc_parameters$new(
+      list(pmcmc_parameter("a", 0.2),
+           pmcmc_parameter("a", 0.1),
+           pmcmc_parameter("a", 0.1),
+           pmcmc_parameter("b", 0.1),
+           pmcmc_parameter("c", 0.1),
+           pmcmc_parameter("c", 0.1)),
+      matrix(1, 6, 6)),
+    "Duplicate parameter names: 'a', 'c'")
+})
+
+
+test_that("named parameters must match parameter names", {
+  pars <- list(pmcmc_parameter("a", 0.2), pmcmc_parameter("b", 0.1))
+  m <- matrix(1, 2, 2)
+  expect_silent(
+    pmcmc_parameters$new(setNames(pars, c("a", "b")), m))
+  expect_error(
+    pmcmc_parameters$new(setNames(pars, c("b", "a")), m),
+    "'parameters' is named, but the names do not match parameters")
+})

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -84,10 +84,10 @@ test_that("run pmcmc with the particle filter and retain history", {
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
 
   pars <- pmcmc_parameters$new(
-    list(beta = pmcmc_parameter(0.2, min = 0, max = 1,
-                                prior = function(p) log(1e-10)),
-         gamma = pmcmc_parameter(0.1, min = 0, max = 1,
-                                 prior = function(p) log(1e-10))),
+    list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
+                         prior = function(p) log(1e-10)),
+         pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
+                         prior = function(p) log(1e-10))),
     proposal = proposal_kernel)
 
   dat <- example_sir()

--- a/tests/testthat/test-utils-assert.R
+++ b/tests/testthat/test-utils-assert.R
@@ -53,3 +53,10 @@ test_that("assert_logical", {
   expect_error(assert_logical("one"), "must be a logical")
   expect_error(assert_logical(1), "must be a logical")
 })
+
+
+test_that("assert_character", {
+  expect_silent(assert_character("string"))
+  expect_error(assert_character(1), "must be a character")
+  expect_error(assert_character(TRUE), "must be a character")
+})


### PR DESCRIPTION
Change how we handle parameter names, making them a component of the parameter, rather than the container. This is something where the Right Thing to do is always hard to see, but in using this in sircovid, I think we have it wrong.

This fixes an issue I can't find where when the prior evaluation fails you do not know *which* one failed. This was extremely annoying to debug. *Edit: it was #48*

Fixes #56 
Fixes #48