### PR TITLE
i60: progress elapsed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.7
+Version: 0.2.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
     dust (>= 0.4.6),
-    progress
+    progress (>= 1.2.0)
 Suggests:
     brio,
     coda,

--- a/R/pmcmc_utils.R
+++ b/R/pmcmc_utils.R
@@ -61,7 +61,7 @@ print.mcstate_pmcmc <- function(x, ...) {
 ## otherwise under R CMD check the progress bar does not run.
 pmcmc_progress <- function(n, show, force = FALSE) {
   if (show) {
-    fmt <- "pmcmc step :current / :total [:bar] ETA :eta"
+    fmt <- "Step :current / :total [:bar] ETA :eta | :elapsedfull so far"
     t0 <- Sys.time()
     callback <- function(p) {
       message(sprintf("Finished %d steps in %s",

--- a/tests/testthat/test-pmcmc-utils.R
+++ b/tests/testthat/test-pmcmc-utils.R
@@ -101,7 +101,7 @@ test_that("progress bar creates progress_bar when progress = TRUE", {
   Sys.sleep(0.2)
   expect_message(
     p(),
-    "pmcmc step 1 / 3 \\[=*>-+] ETA")
+    "Step 1 / 3 \\[=*>-+\\] ETA .* \\| 00:00:[0-9]{2} so far")
   expect_s3_class(
     suppressMessages(p()),
     "progress_bar")


### PR DESCRIPTION
As discussed, this updates the progress bar to include elapsed time in addition to the ETA, putting the ETA in context.

```
> results1 <- pmcmc(pars, p1, 100, TRUE, TRUE, progress = TRUE)
Step 21 / 100 [=======>----------------------------] ETA  8s | 00:00:02 so far
Step 52 / 100 [==================>-----------------] ETA  5s | 00:00:05 so far
Step 91 / 100 [================================>---] ETA  1s | 00:00:09 so far
Finished 100 steps in 10 secs                                                 
```

Fixes #60 