### PR TITLE
i63: named output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.8
+Version: 0.2.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -195,6 +195,7 @@ pmcmc_single_chain <- function(pars, filter, n_steps,
     ## will generate with predict
     trajectories_state <-
       aperm(list_to_array(history_trajectories$get()), c(1, 3, 2))
+    rownames(trajectories_state) <- names(info$index)
     trajectories <- mcstate_trajectories(info$step, info$rate,
                                          trajectories_state, FALSE)
   }

--- a/R/predict.R
+++ b/R/predict.R
@@ -57,6 +57,7 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   n_threads <- n_threads %||% object$predict$n_threads
 
   y <- dust::dust_simulate(model, steps, data, state, index, n_threads, seed)
+  rownames(y) <- names(index)
 
   res <- mcstate_trajectories(steps, object$predict$rate, y, TRUE)
   if (prepend_trajectories) {

--- a/R/predict.R
+++ b/R/predict.R
@@ -57,12 +57,15 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   n_threads <- n_threads %||% object$predict$n_threads
 
   y <- dust::dust_simulate(model, steps, data, state, index, n_threads, seed)
-  rownames(y) <- names(index)
 
   res <- mcstate_trajectories(steps, object$predict$rate, y, TRUE)
   if (prepend_trajectories) {
     res <- bind_mcstate_trajectories(object$trajectories, res)
   }
+
+  ## NOTE: this would be better done against 'y' but preserved through
+  ## bind_mcstate_trajectories
+  rownames(res$state) <- names(index)
 
   res
 }

--- a/R/predict.R
+++ b/R/predict.R
@@ -57,15 +57,12 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   n_threads <- n_threads %||% object$predict$n_threads
 
   y <- dust::dust_simulate(model, steps, data, state, index, n_threads, seed)
+  rownames(y) <- names(index)
 
   res <- mcstate_trajectories(steps, object$predict$rate, y, TRUE)
   if (prepend_trajectories) {
     res <- bind_mcstate_trajectories(object$trajectories, res)
   }
-
-  ## NOTE: this would be better done against 'y' but preserved through
-  ## bind_mcstate_trajectories
-  rownames(res$state) <- names(index)
 
   res
 }

--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -17,6 +17,7 @@ bind_mcstate_trajectories <- function(a, b) {
 
   step <- c(a$step, b$step[-1])
   state <- abind3(a$state, b$state[, , -1, drop = FALSE])
+  rownames(state) <- rownames(b$state) %||% rownames(a$state)
   predicted <- c(a$predicted, b$predicted[-1])
 
   mcstate_trajectories(step, a$rate, state, predicted)

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -271,5 +271,5 @@ test_that("return names on pmcmc output", {
   results2 <- pmcmc(pars, p2, 5, TRUE, TRUE)
 
   expect_null(rownames(results1$trajectories$state))
-  expect_equal(rownames(results2$trajectories$state), c("a", "b", "c")))
+  expect_equal(rownames(results2$trajectories$state), c("a", "b", "c"))
 })

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -244,3 +244,32 @@ test_that("All arguments forwarded to multiple chains", {
   expect_equal(ans1, res[[1]])
   expect_equal(ans2, pmcmc_combine(samples = res))
 })
+
+
+test_that("return names on pmcmc output", {
+  proposal_kernel <- diag(2) * 1e-4
+  row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
+
+  pars <- pmcmc_parameters$new(
+    list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
+                         prior = function(p) log(1e-10)),
+         pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
+                         prior = function(p) log(1e-10))),
+    proposal = proposal_kernel)
+
+  dat <- example_sir()
+  n_particles <- 10
+  index2 <- function(info) list(run = 4L, state = c(a = 1, b = 2, c = 3))
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index)
+  p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = index2)
+
+  set.seed(1)
+  results1 <- pmcmc(pars, p1, 5, TRUE, TRUE)
+  set.seed(1)
+  results2 <- pmcmc(pars, p2, 5, TRUE, TRUE)
+
+  expect_null(rownames(results1$trajectories$state))
+  expect_equal(rownames(results2$trajectories$state), c("a", "b", "c")))
+})

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -131,7 +131,9 @@ test_that("names are copied from index into predictions", {
 
   names(results$predict$index) <- c("a", "b", "c")
   y2 <- pmcmc_predict(results, steps, seed = 1L)
+  y3 <- pmcmc_predict(results, steps, prepend_trajectories = TRUE, seed = 1L)
 
-  expect_null(rownames(y1))
-  expect_equal(rownames(y2), c("a", "b", "c"))
+  expect_null(rownames(y1$state))
+  expect_equal(rownames(y2$state), c("a", "b", "c"))
+  expect_equal(rownames(y3$state), c("a", "b", "c"))
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -122,3 +122,16 @@ test_that("can't prepend history if trajectories not saved", {
     pmcmc_predict(results, steps, prepend_trajectories = TRUE),
     "mcmc was run with return_trajectories = FALSE, can't prepend trajectories")
 })
+
+
+test_that("names are copied from index into predictions", {
+  results <- example_sir_pmcmc()$pmcmc
+  steps <- seq(results$predict$step, by = 4, length.out = 26)
+  y1 <- pmcmc_predict(results, steps, seed = 1L)
+
+  names(results$predict$index) <- c("a", "b", "c")
+  y2 <- pmcmc_predict(results, steps, seed = 1L)
+
+  expect_null(rownames(y1))
+  expect_equal(rownames(y2), c("a", "b", "c"))
+})


### PR DESCRIPTION
Add names to trajectories returned from pmcmc and pmcmc_predict

Fixes #63 