### PR TITLE
i67: keep names when combining chains

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.9
+Version: 0.2.10
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc_tools.R
+++ b/R/pmcmc_tools.R
@@ -158,6 +158,7 @@ combine_trajectories <- function(trajectories) {
     unlist(trajectories_state),
     dim(trajectories_state[[1]]) * c(1, 1, length(trajectories)))
   state <- aperm(trajectories_state, c(1, 3, 2))
+  rownames(state) <- rownames(trajectories[[1]]$state)
 
   ret <- trajectories[[1]]
   ret$state <- state

--- a/tests/testthat/test-pmcmc-tools.R
+++ b/tests/testthat/test-pmcmc-tools.R
@@ -277,3 +277,24 @@ test_that("can sample from a combined chain", {
   expect_true(all(1:3 %in% sub$chain))
   expect_true(all(sub$iteration >= 10))
 })
+
+
+test_that("combining chains keeps rownames", {
+  results <- example_sir_pmcmc2()$results
+
+  nms_t <- c("S", "I", "R")
+  nms_s <- c("S", "I", "R", "inc")
+  for (i in seq_along(results)) {
+    rownames(results[[i]]$trajectories$state) <- nms_t
+    rownames(results[[i]]$state) <- nms_s
+  }
+
+  results1 <- results[[1]]
+  results2 <- results[[2]]
+  results3 <- results[[3]]
+
+  res <- pmcmc_combine(results1, results2, results3)
+
+  expect_equal(rownames(res$state), nms_s)
+  expect_equal(rownames(res$trajectories$state), nms_t)
+})


### PR DESCRIPTION
This PR keeps rownames when combining pmcmc output

Fixes #67 