### PR TITLE
i70 return inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,5 +33,5 @@ Suggests:
     tibble,
     vctrs,
     withr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.10
+Version: 0.2.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -368,20 +368,6 @@ particle_filter <- R6::R6Class(
     },
 
     ##' @description
-    ##' Return a list of information that would be used to restart a
-    ##' simulation (in addition to state). This exists to support internal
-    ##' functions and should not need to be called by end-users.
-    predict_info = function() {
-      ## TODO: this name is terrible.
-      list(n_threads = private$last_model$n_threads(),
-           index = private$last_index_state,
-           seed = private$last_model$rng_state(first_only = TRUE),
-           step = c(private$data$step_start[[1]], private$data$step_end),
-           rate = attr(private$data, "rate", exact = TRUE),
-           inputs = self$inputs())
-    },
-
-    ##' @description
     ##' Return a list of inputs used to configure the particle
     ##' filter. These correspond directly to the argument names for the
     ##' particle filter constructor and are the same as the input

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -378,6 +378,24 @@ particle_filter <- R6::R6Class(
            seed = private$last_model$rng_state(first_only = TRUE),
            step = c(private$data$step_start[[1]], private$data$step_end),
            rate = attr(private$data, "rate", exact = TRUE))
+    },
+
+    ##' @description
+    ##' Return a list of inputs used to configure the particle filter
+    inputs = function() {
+      if (is.null(private$last_model)) {
+        seed <- private$seed
+      } else {
+        private$last_model$rng_state(first_only = TRUE)
+      }
+      list(data = private$data,
+           model = self$model,
+           n_particles = self$n_particles,
+           index = private$index,
+           initial = private$compare,
+           compare = private$compare,
+           n_threads = private$n_threads,
+           seed = seed)
     }
   ))
 

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -377,22 +377,28 @@ particle_filter <- R6::R6Class(
            index = private$last_index_state,
            seed = private$last_model$rng_state(first_only = TRUE),
            step = c(private$data$step_start[[1]], private$data$step_end),
-           rate = attr(private$data, "rate", exact = TRUE))
+           rate = attr(private$data, "rate", exact = TRUE),
+           inputs = self$inputs())
     },
 
     ##' @description
-    ##' Return a list of inputs used to configure the particle filter
+    ##' Return a list of inputs used to configure the particle
+    ##' filter. These correspond directly to the argument names for the
+    ##' particle filter constructor and are the same as the input
+    ##' argument with the exception of `seed`, which is the state of
+    ##' the rng if it has been used (this can be used as a seed to
+    ##' restart the model).
     inputs = function() {
       if (is.null(private$last_model)) {
         seed <- private$seed
       } else {
-        private$last_model$rng_state(first_only = TRUE)
+        seed <- private$last_model$rng_state(first_only = TRUE)
       }
       list(data = private$data,
            model = self$model,
            n_particles = self$n_particles,
            index = private$index,
-           initial = private$compare,
+           initial = private$initial,
            compare = private$compare,
            n_threads = private$n_threads,
            seed = seed)

--- a/R/predict.R
+++ b/R/predict.R
@@ -53,8 +53,8 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   state <- object$state
   data <- apply(object$pars, 1, object$predict$transform)
   index <- object$predict$index
-  model <- object$predict$model
-  n_threads <- n_threads %||% object$predict$n_threads
+  model <- object$predict$filter$model
+  n_threads <- n_threads %||% object$predict$filter$n_threads
 
   y <- dust::dust_simulate(model, steps, data, state, index, n_threads, seed)
   rownames(y) <- names(index)

--- a/R/utils.R
+++ b/R/utils.R
@@ -98,3 +98,8 @@ all_or_none <- function(x) {
 squote <- function(x) {
   sprintf("'%s'", x)
 }
+
+
+r6_private <- function(x) {
+  x[[".__enclos_env__"]]$private
+}

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -80,7 +80,7 @@ at each step that has been run}
 \item \href{#method-run}{\code{particle_filter$run()}}
 \item \href{#method-state}{\code{particle_filter$state()}}
 \item \href{#method-history}{\code{particle_filter$history()}}
-\item \href{#method-predict_info}{\code{particle_filter$predict_info()}}
+\item \href{#method-inputs}{\code{particle_filter$inputs()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -252,14 +252,17 @@ If \code{NULL} we return all particles' histories.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-predict_info"></a>}}
-\if{latex}{\out{\hypertarget{method-predict_info}{}}}
-\subsection{Method \code{predict_info()}}{
-Return a list of information that would be used to restart a
-simulation (in addition to state). This exists to support internal
-functions and should not need to be called by end-users.
+\if{html}{\out{<a id="method-inputs"></a>}}
+\if{latex}{\out{\hypertarget{method-inputs}{}}}
+\subsection{Method \code{inputs()}}{
+Return a list of inputs used to configure the particle
+filter. These correspond directly to the argument names for the
+particle filter constructor and are the same as the input
+argument with the exception of \code{seed}, which is the state of
+the rng if it has been used (this can be used as a seed to
+restart the model).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter$predict_info()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$inputs()}\if{html}{\out{</div>}}
 }
 
 }

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -7,7 +7,11 @@ example_sir <- function() {
     if (is.na(observed$incidence)) {
       return(NULL)
     }
-    exp_noise <- pars$compare$exp_noise %||% 1e6
+    if (is.null(pars$compare$exp_noise)) {
+      exp_noise <- 1e6
+    } else {
+      exp_noise <- pars$compare$exp_noise
+    }
     ## This is on the *filtered* state (i.e., returned by run())
     incidence_modelled <-
       state[1, , drop = TRUE] - prev_state[1, , drop = TRUE]

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -32,7 +32,7 @@ example_sir <- function() {
   data_raw <- data.frame(day = day, incidence = incidence)
   data <- particle_filter_data(data_raw, "day", 4)
   index <- function(info) {
-    list(run = 4L, state = 1:3)
+      list(run = 4L, state = 1:3)
   }
 
   proposal_kernel <- diag(2) * 1e-4
@@ -44,6 +44,10 @@ example_sir <- function() {
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal = proposal_kernel)
+
+  ## Avoid warnings about scope capture that are not important here.
+  environment(index) <- globalenv()
+  environment(compare) <- globalenv()
 
   list(model = model, compare = compare, y0 = y0,
        data_raw = data_raw, data = data, history = history,
@@ -143,9 +147,4 @@ example_sir_pmcmc2 <- function() {
     test_cache$example_sir_pmcmc2 <- dat
   }
   test_cache$example_sir_pmcmc2
-}
-
-
-r6_private <- function(x) {
-  x[[".__enclos_env__"]]$private
 }

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -32,7 +32,7 @@ example_sir <- function() {
   data_raw <- data.frame(day = day, incidence = incidence)
   data <- particle_filter_data(data_raw, "day", 4)
   index <- function(info) {
-      list(run = 4L, state = 1:3)
+    list(run = 4L, state = 1:3)
   }
 
   proposal_kernel <- diag(2) * 1e-4

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -433,3 +433,30 @@ test_that("can filter state on extraction", {
   state <- p$state()
   expect_equal(p$state(2:3), state[2:3, , drop = FALSE])
 })
+
+
+test_that("can return inputs", {
+  dat <- example_sir()
+  n_particles <- 42
+  initial <- function(...) NULL
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index, initial = initial, seed = 100)
+  inputs <- p$inputs()
+  expect_setequal(names(inputs), names(formals(p$initialize)))
+
+  expect_equal(inputs$data, dat$data)
+  expect_equal(inputs$model, dat$model)
+  expect_equal(inputs$n_particles, n_particles)
+  expect_equal(inputs$index, dat$index)
+  expect_equal(inputs$compare, dat$compare)
+  expect_equal(inputs$initial, initial)
+  expect_equal(inputs$seed, 100)
+
+  res <- p$run()
+
+  inputs2 <- p$inputs()
+  expect_type(inputs2$seed, "raw")
+
+  expect_identical(inputs2[names(inputs2) != "seed"],
+                   inputs[names(inputs) != "seed"])
+})

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -273,3 +273,17 @@ test_that("return names on pmcmc output", {
   expect_null(rownames(results1$trajectories$state))
   expect_equal(rownames(results2$trajectories$state), c("a", "b", "c"))
 })
+
+
+test_that("can reconstruct particle filter with pmcmc output", {
+  res <- example_sir_pmcmc()
+  expect_s3_class(res$pmcmc$predict$data, "particle_filter_data")
+  expect_identical(res$pmcmc$predict$data, res$data)
+
+  predict <- res$pmcmc$predict
+
+  p <- particle_filter$new(predict$data, predict$model, 10,
+                           dat$compare,
+                           index = dat$index)
+
+})

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -142,14 +142,12 @@ test_that("run pmcmc with the particle filter and retain history", {
   ## Additional information required to predict
   expect_setequal(
     names(results1$predict),
-    c("transform", "model", "n_threads", "index", "rate", "step", "seed"))
+    c("transform", "index", "rate", "step", "filter"))
   expect_identical(results1$predict$transform, as.list)
-  expect_identical(results1$predict$model, dat$model)
-  expect_equal(results1$predict$n_threads, 1L)
   expect_equal(results1$predict$index, 1:3)
   expect_equal(results1$predict$rate, 4)
   expect_equal(results1$predict$step, last(dat$data$step_end))
-  expect_is(results1$predict$seed, "raw")
+  expect_identical(results1$predict$filter, p1$inputs())
 })
 
 
@@ -174,10 +172,10 @@ test_that("collecting state from model yields an RNG state", {
     r6_private(p1)$last_model$rng_state(),
     r6_private(p2)$last_model$rng_state())
   expect_identical(
-    results2$predict$seed,
+    results2$predict$filter$seed,
     r6_private(p1)$last_model$rng_state()[1:32])
   expect_false(
-    identical(results2$predict$seed, results3$predict$seed))
+    identical(results2$predict$filter$seed, results3$predict$filter$seed))
 })
 
 
@@ -272,18 +270,4 @@ test_that("return names on pmcmc output", {
 
   expect_null(rownames(results1$trajectories$state))
   expect_equal(rownames(results2$trajectories$state), c("a", "b", "c"))
-})
-
-
-test_that("can reconstruct particle filter with pmcmc output", {
-  res <- example_sir_pmcmc()
-  expect_s3_class(res$pmcmc$predict$data, "particle_filter_data")
-  expect_identical(res$pmcmc$predict$data, res$data)
-
-  predict <- res$pmcmc$predict
-
-  p <- particle_filter$new(predict$data, predict$model, 10,
-                           dat$compare,
-                           index = dat$index)
-
 })


### PR DESCRIPTION
This PR allows us to return all inputs to the particle filter, from the particle filter itself and as part of the augmented output for the pmcmc.

This replaces the weird predict_info() method that I never liked (in favour of a second fetch of private data). This removes the predict object's "model", "n_threads" and "seed" elements. There is one affected orderly task:

```
src/rtm_inference_pmcmc_rwc/support.R
190:  sample$predict$model$new(p, 0, 1)$info()$index
```

which needs updating, but this is simply `sample$predict$filter$model$new...`