### PR TITLE
I73 history names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.12
+Version: 0.2.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -364,7 +364,9 @@ particle_filter <- R6::R6Class(
       cidx <- cbind(seq_len(ny),
                     rep(idx, each = ny),
                     rep(seq_len(nt), each = ny * np))
-      array(history_value[cidx], c(ny, np, nt))
+      ret <- array(history_value[cidx], c(ny, np, nt))
+      rownames(ret) <- names(private$last_index_state)
+      ret
     },
 
     ##' @description

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -460,3 +460,31 @@ test_that("can return inputs", {
   expect_identical(inputs2[names(inputs2) != "seed"],
                    inputs[names(inputs) != "seed"])
 })
+
+
+test_that("return names on history, if present", {
+  dat <- example_sir()
+  n_particles <- 42
+  index <- function(info) {
+    list(run = 4L, state = c(S = 1L, I = 2L, R = 3L))
+  }
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = index, seed = 100)
+  p$run(save_history = TRUE)
+  res <- p$history()
+  expect_equal(rownames(res), c("S", "I", "R"))
+})
+
+
+test_that("no names on history, if absent", {
+  dat <- example_sir()
+  n_particles <- 42
+  index <- function(info) {
+    list(run = 4L, state = 1:3)
+  }
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = index, seed = 100)
+  p$run(save_history = TRUE)
+  res <- p$history()
+  expect_null(rownames(res))
+})


### PR DESCRIPTION
This PR adds rownames to the history, if they were present in the index. As noticed on some sircovid work

Fixes #73 