### PR TITLE
Add new rerun_every argument to rerun particle filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.2.15
+Version: 0.2.16
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# mcstate 0.2.16
+
+* `pmcmc` adds new `rerun_every` argument to rerun the particle filter unconditionally.

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -149,6 +149,12 @@ pmcmc_single_chain <- function(pars, initial, filter, n_steps, rerun_every,
     if (i %% rerun_every == 0) {
       curr_llik <- filter$run(pars$model(curr_pars), save_trajectories)
       curr_lpost <- curr_lprior + curr_llik
+      if (save_trajectories) {
+        curr_trajectories <- sample_trajectory(filter$history(particle_idx))
+      }
+      if (save_state) {
+        curr_state <- filter$state()[, particle_idx, drop = TRUE]
+      }
     }
 
     prop_pars <- pars$propose(curr_pars)

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -146,15 +146,15 @@ pmcmc_single_chain <- function(pars, initial, filter, n_steps, rerun_every,
   for (i in seq_len(n_steps)) {
     tick()
 
-    prop_pars <- pars$propose(curr_pars)
-    prop_lprior <- pars$prior(prop_pars)
-    prop_llik <- filter$run(pars$model(prop_pars), save_trajectories)
-    prop_lpost <- prop_lprior + prop_llik
-
     if (i %% rerun_every == 0) {
       curr_llik <- filter$run(pars$model(curr_pars), save_trajectories)
       curr_lpost <- curr_lprior + curr_llik
     }
+
+    prop_pars <- pars$propose(curr_pars)
+    prop_lprior <- pars$prior(prop_pars)
+    prop_llik <- filter$run(pars$model(prop_pars), save_trajectories)
+    prop_lpost <- prop_lprior + prop_llik
 
     if (runif(1) < exp(prop_lpost - curr_lpost)) {
       curr_pars <- prop_pars

--- a/man/pmcmc.Rd
+++ b/man/pmcmc.Rd
@@ -12,7 +12,8 @@ pmcmc(
   save_trajectories = FALSE,
   progress = FALSE,
   n_chains = 1,
-  initial = NULL
+  initial = NULL,
+  rerun_every = Inf
 )
 }
 \arguments{
@@ -61,6 +62,14 @@ initial conditions saved in your \code{pars} object. You can provide
 either a vector of initial conditions, or a matrix with
 \code{n_chains} columns to use a different starting point for each
 chain.}
+
+\item{rerun_every}{Optional integer giving the frequency at which
+we should rerun the particle filter on the current "accepted"
+state.  The default for this (\code{Inf}) will never rerun this
+point, but if you set to 100, then every 100 steps we run the
+particle filter on both the proposed \emph{and} previously accepted
+point before doing the comparison.  This may help "unstick"
+chains, at the cost of some bias in the results.}
 }
 \value{
 A \code{mcstate_pmcmc} object containing \code{pars}

--- a/scripts/generate_vignette_data.R
+++ b/scripts/generate_vignette_data.R
@@ -1,21 +1,24 @@
 set.seed(0)
 
-###
-### SIR model
-###
+##
+## SIR model
+##
 
 # Set up model
 gen_sir <- dust::dust_example("sir")
 dt <- 0.25
-inv_dt <- 1/dt
-sir <- gen_sir$new(data = list(dt = dt, S_ini = 1000, I_ini = 10, beta = 0.2, gamma = 0.1),
+inv_dt <- 1 / dt
+sir <- gen_sir$new(data = list(dt = dt, S_ini = 1000, I_ini = 10,
+                               beta = 0.2, gamma = 0.1),
                    step = 0,
                    n_particles = 1L,
                    n_threads = 1L,
                    seed = 2L)
 
-# Run model forward 100 days, using 4 steps a day
-# Calculate the number of new cases by counting how many susceptibles have been depleted between updates
+## Run model forward 100 days, using 4 steps a day
+##
+## Calculate the number of new cases by counting how many susceptibles
+## have been depleted between updates
 n_steps <- 100
 incidence <- rep(NA, length.out = n_steps)
 true_history <- array(NA_real_, c(length(sir$info()$vars), 1, n_steps + 1))
@@ -28,8 +31,9 @@ for (t in seq_len(n_steps)) {
 }
 
 # Add very simple form of noise
-incidence <- incidence + 
-  round(rnorm(mean = 0, n = length(true_history[3,1,-1]), sd = 0.1*sqrt(true_history[3,1,-1])))
+incidence <- incidence +
+  round(rnorm(mean = 0, n = length(true_history[3, 1, -1]),
+              sd = 0.1 * sqrt(true_history[3, 1, -1])))
 incidence <- unlist(lapply(incidence, max, 0))
 incidence_data <- data.frame(cases = incidence, day = seq_len(n_steps))
 
@@ -40,27 +44,30 @@ write.table(incidence_data, "vignettes/sir_incidence_data.csv",
             row.names = FALSE)
 saveRDS(true_history, "vignettes/sir_true_history.rds", version = 2)
 
-###
-### Model with death data
-###
-
+##
+## Model with death data
+##
 gen_death <- odin.dust::odin_dust("vignettes/deaths.R")
 
-# Set up model
+## Set up model
 dt <- 0.25
-inv_dt <- 1/dt
-sir_death <- gen_death$new(data = list(dt = dt, S_ini = 1000, I_ini = 10, beta = 0.2, gamma = 0.1),
+inv_dt <- 1 / dt
+sir_death <- gen_death$new(data = list(dt = dt, S_ini = 1000, I_ini = 10,
+                                       beta = 0.2, gamma = 0.1),
                            step = 0,
                            n_particles = 1L,
                            n_threads = 1L,
                            seed = 2L)
 
-# Run model forward 100 days, using 4 steps a day
-# Calculate the number of new cases by counting how many susceptibles have been depleted between updates
+## Run model forward 100 days, using 4 steps a day
+##
+## Calculate the number of new cases by counting how many susceptibles
+## have been depleted between updates
 n_steps <- 100
 incidence <- rep(NA, length.out = n_steps)
 deaths <- rep(NA, length.out = n_steps)
-true_history_deaths <- array(NA_real_, c(length(sir_death$info()$vars), 1, n_steps + 1))
+true_history_deaths <- array(NA_real_,
+                             c(length(sir_death$info()$vars), 1, n_steps + 1))
 true_history_deaths[, 1, 1] <- sir_death$state()
 for (t in seq_len(n_steps)) {
   state_start <- sir_death$state()
@@ -69,15 +76,17 @@ for (t in seq_len(n_steps)) {
   incidence[t] <- state_start[2, 1] - state_end[2, 1]
   deaths[t] <- state_end[5, 1] - state_start[5, 1]
 }
-# Add very simple form of noise
+
+## Add very simple form of noise
 missing <- rbinom(n = n_steps, prob = 0.05, size = 1) == 1
 incidence[missing] <- NA
-death_data <- data.frame(cases = incidence, deaths = deaths, day = seq_len(n_steps))
+death_data <- data.frame(cases = incidence,
+                         deaths = deaths,
+                         day = seq_len(n_steps))
 
-# Save outputs
+## Save outputs
 write.table(death_data, "vignettes/death_data.csv",
             sep = ",",
             quote = F,
             row.names = FALSE)
 saveRDS(true_history_deaths, "vignettes/deaths_true_history.rds", version = 2)
-

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -232,13 +232,13 @@ test_that("All arguments forwarded to multiple chains", {
   args <- mockery::mock_args(mock_pmcmc_single_chain)
   ic <- c(a = 0.5, b = 0.5)
   expect_equal(args[[1]],
-               list(dat$pars, ic, dat$filter, 1000, FALSE, FALSE, FALSE))
+               list(dat$pars, ic, dat$filter, 1000, Inf, FALSE, FALSE, FALSE))
   expect_equal(args[[2]],
-               list(dat$pars, ic, dat$filter, 1000, FALSE, FALSE, FALSE))
+               list(dat$pars, ic, dat$filter, 1000, Inf, FALSE, FALSE, FALSE))
   expect_equal(args[[3]],
-               list(dat$pars, ic, dat$filter, 1000, FALSE, FALSE, FALSE))
+               list(dat$pars, ic, dat$filter, 1000, Inf, FALSE, FALSE, FALSE))
   expect_equal(args[[4]],
-               list(dat$pars, ic, dat$filter, 1000, FALSE, FALSE, FALSE))
+               list(dat$pars, ic, dat$filter, 1000, Inf, FALSE, FALSE, FALSE))
 
   expect_equal(ans1, res[[1]])
   expect_equal(ans2, pmcmc_combine(samples = res))
@@ -351,4 +351,32 @@ test_that("can start a pmcmc from a matrix of starting points", {
   res <- pmcmc(dat$pars, dat$filter, 1000, FALSE, FALSE,
                n_chains = 3, initial = initial)
   expect_equal(res$pars[res$iteration == 0, ], t(initial))
+})
+
+
+test_that("can trigger rerunning particle filter", {
+  proposal_kernel <- diag(2) * 1e-4
+  row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
+
+  pars <- pmcmc_parameters$new(
+    list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
+                         prior = function(p) log(1e-10)),
+         pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
+                         prior = function(p) log(1e-10))),
+    proposal = proposal_kernel * 50)
+
+  dat <- example_sir()
+  n_particles <- 100
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index)
+  p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index)
+
+  set.seed(1)
+  res1 <- pmcmc(pars, p1, 30, TRUE, TRUE, rerun_every = 2)
+  expect_lte(max(rle(res1$probabilities[, "log_likelihood"])$lengths), 2)
+
+  set.seed(1)
+  res2 <- pmcmc(pars, p1, 30, TRUE, TRUE, rerun_every = Inf)
+  expect_gt(max(rle(res2$probabilities[, "log_likelihood"])$lengths), 5)
 })

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -380,3 +380,23 @@ test_that("can trigger rerunning particle filter", {
   res2 <- pmcmc(pars, p1, 30, TRUE, TRUE, rerun_every = Inf)
   expect_gt(max(rle(res2$probabilities[, "log_likelihood"])$lengths), 5)
 })
+
+
+test_that("rerunning the particle filter triggers the filter run method", {
+  skip_if_not_installed("mockery")
+  dat <- example_uniform()
+  dat$filter$run <- mockery::mock(1, cycle = TRUE)
+  dat$inputs <- function() NULL
+
+  ## with the dummy version we can['t return history
+  ans <- pmcmc(dat$pars, dat$filter, 10, rerun_every = 2,
+               save_trajectories = FALSE, save_state = FALSE)
+
+  mockery::expect_called(dat$filter$run, 16)
+
+  call_curr <- quote(filter$run(pars$model(curr_pars), save_trajectories))
+  call_prop <- quote(filter$run(pars$model(prop_pars), save_trajectories))
+  expected <- rep(list(call_prop), 16)
+  expected[c(1, seq(4, 16, by = 3))] <- list(call_curr)
+  expect_equal(mockery::mock_calls(dat$filter$run), expected)
+})

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -397,6 +397,6 @@ test_that("rerunning the particle filter triggers the filter run method", {
   call_curr <- quote(filter$run(pars$model(curr_pars), save_trajectories))
   call_prop <- quote(filter$run(pars$model(prop_pars), save_trajectories))
   expected <- rep(list(call_prop), 16)
-  expected[c(1, seq(4, 16, by = 3))] <- list(call_curr)
+  expected[c(1, seq(3, 16, by = 3))] <- list(call_curr)
   expect_equal(mockery::mock_calls(dat$filter$run), expected)
 })


### PR DESCRIPTION
This PR adds an argument `rerun_every` to the `pmcmc` function that will rerun the particle filter periodically on the *accepted* point, reducing the chance of stuck chain at the cost of some bias