### PR TITLE
Save state (#86)

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -81,8 +81,8 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "::set-env name=PACKAGE_VERSION::$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')"
-          echo "::set-env name=PACKAGE_NAME::$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')"
+          echo "PACKAGE_VERSION=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.3.1
+
+* The particle filter can now return the entire model state at points during the run, with argument `save_restart` to `$run()` and method `$restart_state()` (#86)
+
 # mcstate 0.3.0
 
 * `pmcmc` is now controllable via a new `mcstate::pmcmc_control` object

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mcstate 0.3.1
 
 * The particle filter can now return the entire model state at points during the run, with argument `save_restart` to `$run()` and method `$restart_state()` (#86)
+* The `pmcmc` can returned sample restart state using the `save_restart` argument to `mcstate::pmcmc_control` which can be used to restart the pMCMC part way along the time series (see `vignette("restart")`)
 
 # mcstate 0.3.0
 

--- a/R/pmcmc_control.R
+++ b/R/pmcmc_control.R
@@ -77,6 +77,17 @@
 ##'   save space, or use [pmcmc_thin()] after running the
 ##'   MCMC.
 ##'
+##' @param save_restart An integer vector of time points to save
+##'   restart information for; this is in addition to `save_state`
+##'   (which saves the final model state) and saves the full model
+##'   state.  It will use the same trajectory as `save_state` and
+##'   `save_trajectories`. Note that if you use this option you will
+##'   end up with lots of model states and will need to process them
+##'   in order to actually restart the pmcmc or the particle filter
+##'   from this state. The integers correspond to the *time* variable
+##'   in your filter (see [mcstate::particle_filter] for more
+##'   information).
+##'
 ##' @param save_trajectories Logical, indicating if the particle
 ##'   trajectories should be saved during the simulation. If `TRUE`,
 ##'   then a single randomly selected particle's trajectory will be
@@ -110,8 +121,8 @@
 pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
                           n_workers = 1L, n_steps_each = NULL,
                           rerun_every = Inf, use_parallel_seed = FALSE,
-                          save_state = TRUE, save_trajectories = FALSE,
-                          progress = FALSE) {
+                          save_state = TRUE, save_restart = NULL,
+                          save_trajectories = FALSE, progress = FALSE) {
   assert_scalar_positive_integer(n_steps)
   assert_scalar_positive_integer(n_chains)
   assert_scalar_positive_integer(n_workers)
@@ -151,6 +162,11 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
                  n_chains, n_workers))
   }
 
+  if (!is.null(save_restart)) {
+    ## possibly assert_integer(save_restart)?
+    assert_strictly_increasing(save_restart)
+  }
+
   ret <- list(n_steps = n_steps,
               n_chains = n_chains,
               n_workers = n_workers,
@@ -159,6 +175,7 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
               rerun_every = rerun_every,
               use_parallel_seed = use_parallel_seed,
               save_state = save_state,
+              save_restart = save_restart,
               save_trajectories = save_trajectories,
               progress = progress)
   class(ret) <- "pmcmc_control"

--- a/R/pmcmc_tools.R
+++ b/R/pmcmc_tools.R
@@ -131,7 +131,7 @@ pmcmc_combine <- function(..., samples = list(...)) {
   if (is.null(trajectories[[1]])) {
     trajectories <- NULL
   } else {
-    trajectories <- combine_trajectories(trajectories)
+    trajectories <- combine_state(trajectories)
   }
 
   restart <- lapply(samples, "[[", "restart")
@@ -141,10 +141,7 @@ pmcmc_combine <- function(..., samples = list(...)) {
   if (is.null(restart[[1]])) {
     restart <- NULL
   } else {
-    browser()
-    stop("WRITEME")
-    restart <- do.call(cbind, lapply(restart, "[[", "restart"))
-    restart <- combine_trajectories(restart)
+    restart <- combine_state(restart)
   }
 
   ## Use the last state for predict as that will probably have most
@@ -158,22 +155,20 @@ pmcmc_combine <- function(..., samples = list(...)) {
 }
 
 
-combine_trajectories <- function(trajectories) {
-  base <- lapply(trajectories, function(x) x[names(x) != "state"])
+combine_state <- function(x) {
+  base <- lapply(x, function(el) el[names(el) != "state"])
   if (length(unique(base)) != 1L) {
-    stop("trajectories data is inconsistent")
+    stop(sprintf("%s data is inconsistent", deparse(substitute(x))))
   }
 
-  ## This is nasty:
-  trajectories_state <- lapply(trajectories, function(x)
-    aperm(x$state, c(1, 3, 2)))
-  trajectories_state <- array(
-    unlist(trajectories_state),
-    dim(trajectories_state[[1]]) * c(1, 1, length(trajectories)))
-  state <- aperm(trajectories_state, c(1, 3, 2))
-  rownames(state) <- rownames(trajectories[[1]]$state)
+  state <- lapply(x, function(el) aperm(el$state, c(1, 3, 2)))
+  state <- array(
+    unlist(state),
+    dim(state[[1]]) * c(1, 1, length(x)))
+  state <- aperm(state, c(1, 3, 2))
+  rownames(state) <- rownames(x[[1]]$state)
 
-  ret <- trajectories[[1]]
+  ret <- x[[1]]
   ret$state <- state
   ret
 }

--- a/R/pmcmc_tools.R
+++ b/R/pmcmc_tools.R
@@ -134,14 +134,27 @@ pmcmc_combine <- function(..., samples = list(...)) {
     trajectories <- combine_trajectories(trajectories)
   }
 
+  restart <- lapply(samples, "[[", "restart")
+  if (!all_or_none(vlapply(restart, is.null))) {
+    stop("If 'restart' is present for any samples, it must be present for all")
+  }
+  if (is.null(restart[[1]])) {
+    restart <- NULL
+  } else {
+    browser()
+    stop("WRITEME")
+    restart <- do.call(cbind, lapply(restart, "[[", "restart"))
+    restart <- combine_trajectories(restart)
+  }
+
   ## Use the last state for predict as that will probably have most
   ## advanced seed.
   ##
   ## We might check index, rate and step here though.
   predict <- last(samples)$predict
 
-  mcstate_pmcmc(pars, probabilities, state, trajectories, predict,
-                chain, iteration)
+  mcstate_pmcmc(pars, probabilities, state, trajectories, restart,
+                predict, chain, iteration)
 }
 
 

--- a/R/pmcmc_tools.R
+++ b/R/pmcmc_tools.R
@@ -69,6 +69,9 @@ pmcmc_filter <- function(object, i) {
   if (!is.null(object$trajectories)) {
     object$trajectories$state <- object$trajectories$state[, i, , drop = FALSE]
   }
+  if (!is.null(object$restart)) {
+    object$restart$state <- object$restart$state[, i, , drop = FALSE]
+  }
   object
 }
 

--- a/R/pmcmc_utils.R
+++ b/R/pmcmc_utils.R
@@ -1,11 +1,12 @@
-mcstate_pmcmc <- function(pars, probabilities, state, trajectories, predict,
-                          chain = NULL, iteration = NULL) {
+mcstate_pmcmc <- function(pars, probabilities, state, trajectories, restart,
+                          predict, chain = NULL, iteration = NULL) {
   ret <- list(chain = chain,
               iteration = iteration %||% seq.int(0, length.out = nrow(pars)),
               pars = pars,
               probabilities = probabilities,
               state = state,
               trajectories = trajectories,
+              restart = restart,
               predict = predict)
   class(ret) <- "mcstate_pmcmc"
   ret

--- a/R/pmcmc_utils.R
+++ b/R/pmcmc_utils.R
@@ -30,6 +30,15 @@ format.mcstate_pmcmc <- function(x, ...) {
       nrow(trajectories), ncol(trajectories), dim(trajectories)[[3]])
   }
 
+  if (is.null(x$restart)) {
+    str_restart <- sprintf("  restart: (not included)")
+  } else {
+    restart <- x$restart$state
+    str_restart <- sprintf(
+      "  restart: %d x %d x %d array of particle restart state",
+      nrow(restart), ncol(restart), dim(restart)[[3]])
+  }
+
   if (is.null(x$chain)) {
     header <- sprintf("<mcstate_pmcmc> (%d samples)", nrow(x$pars))
   } else {
@@ -47,7 +56,8 @@ format.mcstate_pmcmc <- function(x, ...) {
     strwrap(paste(colnames(x$probabilities), collapse = ", "),
             indent = indent, exdent = indent),
     str_state,
-    str_trajectories)
+    str_trajectories,
+    str_restart)
 }
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ Install from drat with
 
 ```
 # install.packages("drat") # -- if you don't have drat installed
-drat:::add("mrc-ide")
+drat:::add("ncov-ic")
 install.packages("mcstate")
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install from drat with
 
 ```
 # install.packages("drat") # -- if you don't have drat installed
-drat:::add("mrc-ide")
+drat:::add("ncov-ic")
 install.packages("mcstate")
 ```
 

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -80,6 +80,7 @@ at each step that has been run}
 \item \href{#method-run}{\code{particle_filter$run()}}
 \item \href{#method-state}{\code{particle_filter$state()}}
 \item \href{#method-history}{\code{particle_filter$history()}}
+\item \href{#method-restart_state}{\code{particle_filter$restart_state()}}
 \item \href{#method-inputs}{\code{particle_filter$inputs()}}
 \item \href{#method-set_n_threads}{\code{particle_filter$set_n_threads()}}
 }
@@ -180,7 +181,7 @@ Run the particle filter}
 \if{latex}{\out{\hypertarget{method-run}{}}}
 \subsection{Method \code{run()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run(pars = list(), save_history = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run(pars = list(), save_history = FALSE, save_restart = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -199,6 +200,12 @@ are silently ignored by dust models.}
 \item{\code{save_history}}{Logical, indicating if the history of all
 particles should be saved. If saving history, then it can be
 queried later with the \verb{$history} method on the object.}
+
+\item{\code{save_restart}}{An integer vector of time points to save
+restart infomation for. These are in terms of your underlying time
+variable (the \code{time} column in \code{\link[=particle_filter_data]{particle_filter_data()}}) not in
+terms of steps. The state will be saved after the particle
+filtering operation (i.e., at the end of the step).}
 }
 \if{html}{\out{</div>}}
 }
@@ -248,6 +255,37 @@ time point.
 \describe{
 \item{\code{index_particle}}{Optional vector of particle indices to return.
 If \code{NULL} we return all particles' histories.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-restart_state"></a>}}
+\if{latex}{\out{\hypertarget{method-restart_state}{}}}
+\subsection{Method \code{restart_state()}}{
+Return the full particle filter state at points back in time
+that were saved with the \code{save_restart} argument to
+\verb{$run()}. If available, this will return a 3d array, with
+dimensions representing (1) particle state, (2) particle index,
+(3) time point. This could be quite large, especially if you
+are using the \code{index} argument to create the particle filter
+and return a subset of all state generally. It is also
+different to the saved trajectories returned by \verb{$history()}
+because earlier saved state is not filtered by later filtering
+(in the history we return the tree of history representing the
+histories of the \emph{final} particles, here we are returning all
+particles at the requested point, regardless if they appear in
+the set of particles that make it to the end of the
+simulation).
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$restart_state(index_particle = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index_particle}}{Optional vector of particle indices to return.
+If \code{NULL} we return all particles' states.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/pmcmc_control.Rd
+++ b/man/pmcmc_control.Rd
@@ -13,6 +13,7 @@ pmcmc_control(
   rerun_every = Inf,
   use_parallel_seed = FALSE,
   save_state = TRUE,
+  save_restart = NULL,
   save_trajectories = FALSE,
   progress = FALSE
 )
@@ -83,6 +84,17 @@ cause \code{n_state} * \code{n_steps} of data to be output
 alongside your results. Set this argument to \code{FALSE} to
 save space, or use \code{\link[=pmcmc_thin]{pmcmc_thin()}} after running the
 MCMC.}
+
+\item{save_restart}{An integer vector of time points to save
+restart information for; this is in addition to \code{save_state}
+(which saves the final model state) and saves the full model
+state.  It will use the same trajectory as \code{save_state} and
+\code{save_trajectories}. Note that if you use this option you will
+end up with lots of model states and will need to process them
+in order to actually restart the pmcmc or the particle filter
+from this state. The integers correspond to the \emph{time} variable
+in your filter (see \link{particle_filter} for more
+information).}
 
 \item{save_trajectories}{Logical, indicating if the particle
 trajectories should be saved during the simulation. If \code{TRUE},

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -147,7 +147,8 @@ example_sir_pmcmc2 <- function() {
                              index = dat$index)
     set.seed(1)
 
-    control <- pmcmc_control(30, save_state = TRUE, save_trajectories = TRUE)
+    control <- pmcmc_control(30, save_state = TRUE, save_trajectories = TRUE,
+                             save_restart = 40)
 
     dat$results <- list(
       pmcmc(dat$pars, p, control = control),

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -39,7 +39,7 @@ example_sir <- function() {
     list(run = 4L, state = 1:3)
   }
 
-  proposal_kernel <- diag(2) * 1e-4
+  proposal_kernel <- rbind(c(0.00057, 0.00034), c(0.00034, 0.00026))
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
 
   pars <- pmcmc_parameters$new(

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -130,7 +130,8 @@ example_sir_pmcmc <- function() {
     p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                              index = dat$index)
     set.seed(1)
-    control <- pmcmc_control(30, save_state = TRUE, save_trajectories = TRUE)
+    control <- pmcmc_control(30, save_state = TRUE, save_trajectories = TRUE,
+                             save_restart = 40)
     dat$pmcmc <- pmcmc(dat$pars, p, control = control)
     test_cache$example_sir_pmcmc <- dat
   }

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -417,6 +417,9 @@ test_that("can't get state or history until model is run", {
   expect_error(
     p$history(),
     "Model has not yet been run")
+  expect_error(
+    p$restart_state(),
+    "Model has not yet been run")
 })
 
 

--- a/tests/testthat/test-pmcmc-control.R
+++ b/tests/testthat/test-pmcmc-control.R
@@ -36,3 +36,14 @@ test_that("If not given, n_run_each is 10% of n_steps", {
     pmcmc_control(105, n_chains = 2, n_workers = 2)$n_steps_each,
     11)
 })
+
+
+test_that("specify save_restart", {
+  expect_null(pmcmc_control(100, save_restart = NULL)$save_restart)
+  expect_equal(pmcmc_control(100, save_restart = 1)$save_restart, 1)
+  expect_equal(pmcmc_control(100, save_restart = c(10, 20))$save_restart,
+               c(10, 20))
+  expect_error(
+    pmcmc_control(100, save_restart = c(20, 10)),
+    "'save_restart' must be strictly increasing")
+})

--- a/tests/testthat/test-pmcmc-tools.R
+++ b/tests/testthat/test-pmcmc-tools.R
@@ -76,19 +76,23 @@ test_that("can combine chains", {
   n_particles <- nrow(results1$state)
   n_index <- nrow(results1$trajectories$state)
   n_time <- dim(results1$trajectories$state)[[3]]
+  n_restart <- dim(results1$restart$state)[[3]]
+  n_state <- nrow(results1$state)
 
   n_mcmc3 <- n_mcmc * 3
 
   expect_equal(dim(res$pars), c(n_mcmc3, n_par))
   expect_equal(dim(res$probabilities), c(n_mcmc3, 3))
-  expect_equal(dim(res$state), c(nrow(results1$state), n_mcmc3))
+  expect_equal(dim(res$state), c(n_state, n_mcmc3))
   expect_equal(dim(res$trajectories$state), c(n_index, n_mcmc3, n_time))
+  expect_equal(dim(res$restart$state), c(n_state, n_mcmc3, n_restart))
 
   i <- seq_len(n_mcmc) + n_mcmc
   expect_equal(res$pars[i, ], results2$pars)
   expect_equal(res$probabilities[i, ], results2$probabilities)
   expect_equal(res$state[, i], results2$state)
   expect_equal(res$trajectories$state[, i, ], results2$trajectories$state)
+  expect_equal(res$restart$state[, i, , drop = FALSE], results2$restart$state)
 })
 
 

--- a/tests/testthat/test-pmcmc-tools.R
+++ b/tests/testthat/test-pmcmc-tools.R
@@ -14,6 +14,8 @@ test_that("discarding burnin drops beginnings of chain", {
   expect_identical(res$probabilities, results$probabilities[i, ])
   expect_identical(res$state, results$state[, i])
   expect_identical(res$trajectories$state, results$trajectories$state[, i, ])
+  expect_identical(res$restart$state,
+                   results$restart$state[, i, , drop = FALSE])
 })
 
 
@@ -25,6 +27,8 @@ test_that("thinning drops all over chain", {
   expect_identical(res$probabilities, results$probabilities[i, ])
   expect_identical(res$state, results$state[, i])
   expect_identical(res$trajectories$state, results$trajectories$state[, i, ])
+  expect_identical(res$restart$state,
+                   results$restart$state[, i, , drop = FALSE])
 })
 
 
@@ -36,6 +40,8 @@ test_that("burnin and thin can be used together", {
   expect_identical(res$probabilities, results$probabilities[i, ])
   expect_identical(res$state, results$state[, i])
   expect_identical(res$trajectories$state, results$trajectories$state[, i, ])
+  expect_identical(res$restart$state,
+                   results$restart$state[, i, , drop = FALSE])
 })
 
 

--- a/tests/testthat/test-pmcmc-tools.R
+++ b/tests/testthat/test-pmcmc-tools.R
@@ -242,6 +242,16 @@ test_that("Can't combine chains that differ in if they have trajectories", {
 })
 
 
+test_that("Can't combine chains that differ in if they have restart", {
+  results <- example_sir_pmcmc2()$results
+  a <- results[[1]]
+  a$restart <- NULL
+  expect_error(
+    pmcmc_combine(a, results[[2]]),
+    "If 'restart' is present for any samples, it must be present for all")
+})
+
+
 test_that("Can't combine inconsistent trajectories", {
   results <- example_sir_pmcmc2()$results
   a <- results[[1]]

--- a/tests/testthat/test-pmcmc-utils.R
+++ b/tests/testthat/test-pmcmc-utils.R
@@ -4,7 +4,7 @@ test_that("format and print the simplest object", {
   pars <- matrix(NA_real_, 10, 4,
                  dimnames = list(NULL, c("a", "b", "c", "d")))
   probs <- matrix(NA_real_, 10, 3, dimnames = list(NULL, c("x", "y", "z")))
-  x <- mcstate_pmcmc(pars, probs, NULL, NULL, NULL)
+  x <- mcstate_pmcmc(pars, probs, NULL, NULL, NULL, NULL)
 
   expected <- c(
     "<mcstate_pmcmc> (10 samples)",
@@ -27,8 +27,9 @@ test_that("format and print with state", {
   state <- matrix(NA_real_, 4, 10)
   trajectories <- list(state = array(NA_real_, c(4, 10, 20)))
   predict <- NULL
+  restart <- NULL
 
-  x <- mcstate_pmcmc(pars, probs, state, trajectories, predict)
+  x <- mcstate_pmcmc(pars, probs, state, trajectories, predict, restart)
 
   expected <- c(
     "<mcstate_pmcmc> (10 samples)",
@@ -67,7 +68,7 @@ test_that("wrap long variable names nicely", {
   probs <- matrix(NA_real_, 10, 3, dimnames = list(NULL, c("x", "y", "z")))
   x <- withr::with_options(
     list(width = 80),
-    format(mcstate_pmcmc(pars, probs, NULL, NULL, NULL)))
+    format(mcstate_pmcmc(pars, probs, NULL, NULL, NULL, NULL)))
   expect_equal(
     x[[3]],
     "    aaaaaaaaaa, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc,")

--- a/tests/testthat/test-pmcmc-utils.R
+++ b/tests/testthat/test-pmcmc-utils.R
@@ -13,7 +13,8 @@ test_that("format and print the simplest object", {
     "  probabilities: 10 x 3 matrix of log-probabilities",
     "    x, y, z",
     "  state: (not included)",
-    "  trajectories: (not included)")
+    "  trajectories: (not included)",
+    "  restart: (not included)")
 
   expect_equal(format(x), expected)
   expect_output(print(x), paste(expected, collapse = "\n"), fixed = TRUE)
@@ -27,9 +28,9 @@ test_that("format and print with state", {
   state <- matrix(NA_real_, 4, 10)
   trajectories <- list(state = array(NA_real_, c(4, 10, 20)))
   predict <- NULL
-  restart <- NULL
+  restart <- list(date = 1, state = array(NA_real_, c(4, 10, 1)))
 
-  x <- mcstate_pmcmc(pars, probs, state, trajectories, predict, restart)
+  x <- mcstate_pmcmc(pars, probs, state, trajectories, restart, predict)
 
   expected <- c(
     "<mcstate_pmcmc> (10 samples)",
@@ -38,7 +39,8 @@ test_that("format and print with state", {
     "  probabilities: 10 x 3 matrix of log-probabilities",
     "    x, y, z",
     "  state: 4 x 10 matrix of final states",
-    "  trajectories: 4 x 10 x 20 array of particle trajectories")
+    "  trajectories: 4 x 10 x 20 array of particle trajectories",
+    "  restart: 4 x 10 x 1 array of particle restart state")
 
   expect_equal(format(x), expected)
   expect_output(print(x), paste(expected, collapse = "\n"), fixed = TRUE)
@@ -55,7 +57,8 @@ test_that("print multichain object", {
     "  probabilities: 93 x 3 matrix of log-probabilities",
     "    log_prior, log_likelihood, log_posterior",
     "  state: 4 x 93 matrix of final states",
-    "  trajectories: 3 x 93 x 101 array of particle trajectories")
+    "  trajectories: 3 x 93 x 101 array of particle trajectories",
+    "  restart: 4 x 93 x 1 array of particle restart state")
 
   expect_equal(format(x), expected)
   expect_output(print(x), paste(expected, collapse = "\n"), fixed = TRUE)

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -111,7 +111,7 @@ test_that("run pmcmc with the particle filter and retain history", {
   expect_setequal(
     names(results1),
     c("chain", "iteration",
-      "pars", "probabilities", "state", "trajectories", "predict"))
+      "pars", "probabilities", "state", "trajectories", "restart", "predict"))
 
   expect_null(results1$chain)
   expect_equal(results1$iteration, 0:30)

--- a/vignettes/restart.Rmd
+++ b/vignettes/restart.Rmd
@@ -127,7 +127,8 @@ dim(res1$restart$state)
 This sample includes variablility over the pmcmc run:
 
 ```{r}
-hist(res1$restart$state[2, , ], xlab = "Number infected")
+hist(res1$restart$state[2, , ], xlab = "Number infected",
+     main = "Distribution of number infected over mcmc samples")
 ```
 
 This matrix includes all information to restart the stochastic process and we can use this to run a pmcmc that starts the particle filter that runs over data starting from day 40. Note that this is *not* the same model as it does fit to the first 40 days of the epidemic so we expect parameters to differ (it's a bit like allowing a break in parameters at day = 40 except our initial parameter sets here *do* include both parts.

--- a/vignettes/restart.Rmd
+++ b/vignettes/restart.Rmd
@@ -1,0 +1,191 @@
+---
+title: "Restarting pMCMC"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Restarting pMCMC}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 5
+)
+lang_output <- function(x, lang) {
+  cat(c(sprintf("```%s", lang), x, "```"), sep = "\n")
+}
+r_output <- function(x) lang_output(x, "r")
+```
+
+We are experimenting with an ability to "restart" the simulation at a point in time based on the outcome of a MCMC run. The motivating reason to do this is in our [`sircovid`](https://mrc-ide.github.io/sircovid/) model where run an epidemiological model with a number of time varying parameters corresponding to interventions which leads to a number of "waves" of infections. We want to be able to restart the simulation from the trough between two waves so that we can avoid refitting the first peak and better capture changes in parameters as the epidemic unfolds.
+
+To illustrate this problem and the solution we will use a much simpler model which does not show recurrent waves of infection, so we will contrive points to restart.  This example picks up from the `vignette("sir_models")` vignette.
+
+## Setup
+
+```{r}
+incidence <- read.csv("sir_incidence_data.csv")
+plot(cases ~ day, incidence,
+     type = "o", xlab = "Day", ylab = "New cases", pch = 19)
+```
+
+```{r}
+history <- readRDS("sir_true_history.rds")
+history <- t(drop(history))
+colnames(history) <- c("S", "I", "R", "cases")
+history <- data.frame(t = seq_len(nrow(history)) - 1L, history)
+matplot(history$t, history[c("S", "I", "R")], type = "l", lty = 1,
+        xlab = "Day", ylab = "Variable")
+```
+
+```{r}
+sir <- dust::dust_example("sir")
+dt <- 0.25
+data <- mcstate::particle_filter_data(incidence, time = "day", rate = 1 / dt)
+```
+
+A comparison function
+
+```{r}
+compare <- function(state, prev_state, observed, pars = NULL) {
+  if (is.na(observed$cases)) {
+    return(NULL)
+  }
+  exp_noise <- 1e6
+  incidence_modelled <- state[1, , drop = TRUE] - prev_state[1, , drop = TRUE]
+  incidence_observed <- observed$cases
+  lambda <- incidence_modelled +
+    rexp(n = length(incidence_modelled), rate = exp_noise)
+  dpois(x = incidence_observed, lambda = lambda, log = TRUE)
+}
+```
+
+An index function for filtering the run state
+
+```{r}
+index <- function(info) {
+  list(run = 4L, state = 1:4)
+}
+```
+
+Parameter information for the pMCMC, including a roughly tuned kernel so that we get adequate mixing
+
+```{r}
+proposal_kernel <- rbind(c(0.00057, 0.00034), c(0.00034, 0.00026))
+pars <- mcstate::pmcmc_parameters$new(
+  list(mcstate::pmcmc_parameter("beta", 0.2, min = 0, max = 1,
+                                prior = function(p) log(1e-10)),
+       mcstate::pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
+                                prior = function(p) log(1e-10))),
+  proposal = proposal_kernel)
+```
+
+## All-in-one
+
+Run a pMCMC with 100 particles for the full length of the data. This means that we are fitting to the entire series.
+
+```{r}
+n_particles <- 100
+p1 <- mcstate::particle_filter$new(data, sir, n_particles, compare,
+                                   index = index,
+                                   n_threads = dust::dust_openmp_threads())
+control1 <- mcstate::pmcmc_control(500, save_trajectories = TRUE,
+                                   save_state = TRUE, save_restart = 40)
+res1 <- mcstate::pmcmc(pars, p1, control = control1)
+```
+
+Here's the trajectories showing the number of people infected
+
+```{r}
+t <- 0:100
+matplot(t, t(res1$trajectories$state[2, , ]), type = "l", lty = 1,
+        col = "#00000011", xlab =  "Day", ylab = "Infected")
+points(I ~ t, history, pch = 19, col = "blue")
+```
+
+And the daily incidence
+
+```{r}
+matplot(t[-1], diff(t(res1$trajectories$state[4, , ])), type = "l",
+        lty = 1, col = "#00000005", xlab = "Day", ylab = "Daily incidence")
+points(cases ~ day, incidence, col = "blue", pch = 19)
+```
+
+## Restarting
+
+In the `mcstate::pmcmc_control` call above we added `save_restart = 40`; this means that we save the entire internal state of a single particle at time step 40 (this is the "day" time, not the model step).
+
+The restart state is a 3d array with dimensions corresponding to (1) model state, (2) MCMC sample, (3) restart time (a vector of times can be provided to `save_restart` but here just one time was returned).
+
+```{r}
+dim(res1$restart$state)
+```
+
+This sample includes variablility over the pmcmc run:
+
+```{r}
+hist(res1$restart$state[2, , ], xlab = "Number infected")
+```
+
+This matrix includes all information to restart the stochastic process and we can use this to run a pmcmc that starts the particle filter that runs over data starting from day 40. Note that this is *not* the same model as it does fit to the first 40 days of the epidemic so we expect parameters to differ (it's a bit like allowing a break in parameters at day = 40 except our initial parameter sets here *do* include both parts.
+
+The key part is to create an `initial` function for the particle function that will create suitable initial conditions. We do this by sampling `n_particles` worth of particles out of this matrix. (The `initial` function must conform to mcstate's interface so we accept `info` and `pars` here even though we ignore them)
+
+```{r}
+s <- res1$restart$state[, , 1]
+initial <- function(info, n_particles, pars) {
+  list(state = s[, sample.int(ncol(s), n_particles, replace = TRUE)])
+}
+```
+
+Then subset the data that we will fit to and create a new particle filter
+
+```{r}
+data2 <- data[data$day_start >= 40, ]
+p2 <- mcstate::particle_filter$new(data2, sir, n_particles, compare,
+                                   index = index, initial = initial,
+                                   n_threads = dust::dust_openmp_threads())
+```
+
+And run a pMCMC that fits parmeters to the second half of the epidemic
+
+```{r}
+control2 <- mcstate::pmcmc_control(500, save_trajectories = TRUE,
+                                   save_state = TRUE)
+res2 <- mcstate::pmcmc(pars, p2, control = control2)
+```
+
+Plot of the number of people infected over time with the overall model (black) and the restarted model (red) with observed data (blue)
+
+```{r}
+t <- 0:100
+t2 <- 40:100
+matplot(t, t(res1$trajectories$state[2, , ]), type = "l", lty = 1,
+        col = "#00000005", xlab =  "Day", ylab = "Infected")
+matlines(t2, t(res2$trajectories$state[2, , ]), lty = 1,
+         col = "#ff000011")
+points(I ~ t, history, pch = 19, col = "blue")
+```
+
+Daily incidence, which is what the model actually fits to
+
+```{r}
+matplot(t[-1], diff(t(res1$trajectories$state[4, , ])), type = "l",
+        lty = 1, col = "#00000002", xlab = "Day", ylab = "Daily incidence")
+matlines(t2[-1], diff(t(res2$trajectories$state[4, , ])),
+        lty = 1, col = "#ff000005")
+points(cases ~ day, incidence, col = "blue", pch = 19)
+```
+
+The parameter estimates, which are a similar but not identical distribution
+
+```{r}
+plot(res1$pars,
+     xlim = range(res1$pars[, 1], res2$pars[, 1]),
+     ylim = range(res1$pars[, 2], res2$pars[, 2]), pch = 19,
+     col = "#0000ff55")
+points(res2$pars, col = "#ff000055", pch = 19)
+```


### PR DESCRIPTION
Allows the particle filter to save the complete internal state during a run so that it may be restarted.

Allow this to be saved from the pmcmc

Then demonstrate how this can be used to restart the pmcmc

Fixes #86