### PR TITLE
Fix typo in sir_models.Rmd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.4.2
+
+* Fix typo in `sir_models.Rmd`
+
 # mcstate 0.4.1
 
 * New `$fix()` method on `pmcmc_parameters` objects for fixing the value for a subset of parameters before running with `pmcmc` (#98)

--- a/vignettes/sir_models.Rmd
+++ b/vignettes/sir_models.Rmd
@@ -42,7 +42,7 @@ Discretising this model in time steps of width $dt$ gives the following update e
 $$\begin{align*}
 S_{t+1} &= S_t - n_{SI} \\
 I_{t+1} &= I_t + n_{SI} - n_{IR} \\
-R_{t+1} &= R_t - n_{IR}
+R_{t+1} &= R_t + n_{IR}
 \end{align*}$$
 
 where


### PR DESCRIPTION
Fixed typo from `-` to `+` in `R_{t+1}` of `sir_models.Rmd`