### PR TITLE
Fix performance regression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.4.4
+
+* Fix performance regression added in 0.4.3
+
 # mcstate 0.4.3
 
 * Support for incrementally running a particle filter (up to some point in the time series) and forking these partial runs; see the `$begin_run` method on the particle filter (#78)

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -223,17 +223,11 @@ particle_filter <- R6::R6Class(
     ##' (`-Inf` if the model is impossible)
     run = function(pars = list(), save_history = FALSE, save_restart = NULL) {
       obj <- self$run_begin(pars, save_history, save_restart)
-      ll <- 0
-      while (!obj$complete) {
-        ll <- obj$step()
-        if (!is.finite(ll)) {
-          break
-        }
-      }
+      obj$run()
       private$last_history <- obj$history
       private$last_model <- obj$model
       private$last_restart_state <- obj$restart_state
-      ll
+      obj$log_likelihood
     },
 
     ##' @description Begin a particle filter run. This is part of the

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -20,6 +20,7 @@ particle_filter_state <- R6::R6Class(
     data = NULL,
     data_split = NULL,
     steps = NULL,
+    n_steps = NULL,
     n_particles = NULL,
     n_threads = NULL,
     initial = NULL,
@@ -34,10 +35,6 @@ particle_filter_state <- R6::R6Class(
     ##' @field model The dust model generator being simulated (cannot be
     ##'   re-bound)
     model = NULL,
-
-    ##' @field complete Logical, indicating if the particle filter has
-    ##'   reached the end of the data.
-    complete = FALSE,
 
     ##' @field history The particle history, if created with
     ##'   `save_history = TRUE`. This is an internal format subject to
@@ -123,6 +120,7 @@ particle_filter_state <- R6::R6Class(
       private$data <- data
       private$data_split <- data_split
       private$steps <- steps
+      private$n_steps <- nrow(steps)
       private$n_particles <- n_particles
       private$n_threads <- n_threads
       private$initial <- initial
@@ -136,61 +134,114 @@ particle_filter_state <- R6::R6Class(
       self$log_likelihood <- 0.0
     },
 
+    ##' @description Run the particle filter to the end of the data. This is
+    ##' a convenience function around `$step()` which provides the correct
+    ##' value of `step_index`
+    run = function() {
+      self$step(private$n_steps)
+    },
+
     ##' @description Take a step with the particle filter. This moves
     ##' the particle filter forward one step within the *data* (which
     ##' may correspond to more than one step with your model) and
     ##' returns the likelihood so far.
-    step = function() {
-      if (self$complete) {
-        stop("The particle filter has reached the end of the data")
+    ##'
+    ##' @param step_index The step *index* to move to. This is not the same
+    ##' as the model step, nor time, so be careful. It is an error to provide
+    ##' a value here that is lower than the current step index, or past
+    ##' the end of the data.
+    step = function(step_index) {
+      steps <- private$steps
+      n_steps <- private$n_steps
+      curr <- private$current_step_index
+      if (curr >= n_steps) {
+        stop("Particle filter has reached the end of the data")
       }
-      private$current_step_index <- private$current_step_index + 1L
-      self$complete <- private$current_step_index >= nrow(private$steps)
-      step <- private$current_step_index
-      step_end <- private$steps[step, 2]
-      save_history <- !is.null(self$history)
+      if (step_index > n_steps) {
+        stop(sprintf("step_index %d is beyond the length of the data (max %d)",
+                     step_index, n_steps))
+      }
+      if (step_index <= curr) {
+        stop(sprintf(
+          "Particle filter has already run step index %d (to model step %d)",
+          step_index, steps[step_index, 2]))
+      }
 
-      state <- self$model$run(step_end)
+      model <- self$model
+
+      compare <- private$compare
+      steps <- private$steps
+      data_split <- private$data_split
+      pars <- private$pars
+
+      restart_state <- self$restart_state
+      save_restart_step <- private$save_restart_step
+      save_restart <- !is.null(restart_state)
+
+      history <- self$history
+      save_history <- !is.null(history)
+      save_history_index <- self$history$index
+      history_value <- history$value
+      history_order <- history$order
+
+      log_likelihood <- self$log_likelihood
+      n_particles <- private$n_particles
+
+      for (t in seq(curr + 1L, step_index)) {
+        step_end <- steps[t, 2L]
+        state <- model$run(step_end)
+
+        if (save_history) {
+          history_value[, , t + 1L] <- model$state(save_history_index)
+        }
+
+        if (is.null(compare)) {
+          log_weights <- model$compare_data()
+        } else {
+          log_weights <- compare(state, data_split[[t]], pars)
+        }
+
+        if (is.null(log_weights)) {
+          if (save_history) {
+            history_order[, t + 1L] <- seq_len(n_particles)
+          }
+          log_likelihood_step <- NA_real_
+        } else {
+          weights <- scale_log_weights(log_weights)
+          log_likelihood_step <- weights$average
+          log_likelihood <- log_likelihood + log_likelihood_step
+          if (log_likelihood == -Inf) {
+            break
+          }
+
+          kappa <- particle_resample(weights$weights)
+          model$reorder(kappa)
+          if (save_history) {
+            history_order[, t + 1L] <- kappa
+          }
+        }
+
+        if (save_restart) {
+          i_restart <- match(step_end, save_restart_step)
+          if (!is.na(i_restart)) {
+            restart_state[, , i_restart] <- model$state()
+          }
+        }
+      }
+
+      self$log_likelihood_step <- log_likelihood_step
+      self$log_likelihood <- log_likelihood
+      private$current_step_index <- step_index
       if (save_history) {
-        self$history$value[, , step + 1L] <-
-          self$model$state(self$history$index)
+        history$value <- history_value
+        history$order <- history_order
+        self$history <- history
+      }
+      if (save_restart) {
+        self$restart_state <- restart_state
       }
 
-      if (is.null(private$compare)) {
-        log_weights <- self$model$compare_data()
-      } else {
-        log_weights <- private$compare(state, private$data_split[[step]],
-                                       private$pars)
-      }
-
-      if (is.null(log_weights)) {
-        if (save_history) {
-          self$history$order[, step + 1L] <- seq_len(ncol(state))
-        }
-      } else {
-        weights <- scale_log_weights(log_weights)
-        self$log_likelihood_step <- weights$average
-        self$log_likelihood <- self$log_likelihood + weights$average
-        if (self$log_likelihood == -Inf) {
-          self$complete <- TRUE
-          return(-Inf)
-        }
-
-        kappa <- particle_resample(weights$weights)
-        self$model$reorder(kappa)
-        if (save_history) {
-          self$history$order[, step + 1L] <- kappa
-        }
-      }
-
-      if (!is.null(private$save_restart_step)) {
-        i_restart <- match(step_end, private$save_restart_step)
-        if (!is.na(i_restart)) {
-          self$restart_state[, , i_restart] <- self$model$state()
-        }
-      }
-
-      self$log_likelihood
+      log_likelihood
     },
 
     ##' @description Create a new `particle_filter_state` object based
@@ -213,9 +264,7 @@ particle_filter_state <- R6::R6Class(
         save_history, private$save_restart)
 
       ## Run it up to the same point
-      for (i in seq_len(private$current_step_index)) {
-        ret$step()
-      }
+      ret$step(private$current_step_index)
 
       ## Set the seed in the parent model
       self$model$set_rng_state(ret$model$rng_state())

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -147,7 +147,8 @@ particle_filter_state <- R6::R6Class(
     ##' returns the likelihood so far.
     ##'
     ##' @param step_index The step *index* to move to. This is not the same
-    ##' as the model step, nor time, so be careful. It is an error to provide
+    ##' as the model step, nor time, so be careful (it's the index within
+    ##' the data provided to the filter). It is an error to provide
     ##' a value here that is lower than the current step index, or past
     ##' the end of the data.
     step = function(step_index) {

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -100,8 +100,9 @@ returns the likelihood so far.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{step_index}}{The step \emph{index} to move to. This is not the same as
-the model step, nor time, so be careful. It is an error to provide
+\item{\code{step_index}}{The step \emph{index} to move to. This is not the same
+as the model step, nor time, so be careful (it's the index within
+the data provided to the filter). It is an error to provide
 a value here that is lower than the current step index, or past
 the end of the data.}
 }

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -21,9 +21,6 @@ them, but don't).
 \item{\code{model}}{The dust model generator being simulated (cannot be
 re-bound)}
 
-\item{\code{complete}}{Logical, indicating if the particle filter has
-reached the end of the data.}
-
 \item{\code{history}}{The particle history, if created with
 \code{save_history = TRUE}. This is an internal format subject to}
 
@@ -44,6 +41,7 @@ last call to \verb{$step()}.}
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{particle_filter_state$new()}}
+\item \href{#method-run}{\code{particle_filter_state$run()}}
 \item \href{#method-step}{\code{particle_filter_state$step()}}
 \item \href{#method-fork}{\code{particle_filter_state$fork()}}
 }
@@ -76,6 +74,18 @@ documented.
 
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-run"></a>}}
+\if{latex}{\out{\hypertarget{method-run}{}}}
+\subsection{Method \code{run()}}{
+Run the particle filter to the end of the data. This is
+a convenience function around \verb{$step()} which provides the correct
+value of \code{step_index}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter_state$run()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-step"></a>}}
 \if{latex}{\out{\hypertarget{method-step}{}}}
 \subsection{Method \code{step()}}{
@@ -84,9 +94,19 @@ the particle filter forward one step within the \emph{data} (which
 may correspond to more than one step with your model) and
 returns the likelihood so far.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter_state$step()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter_state$step(step_index)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{step_index}}{The step \emph{index} to move to. This is not the same as
+the model step, nor time, so be careful. It is an error to provide
+a value here that is lower than the current step index, or past
+the end of the data.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-fork"></a>}}


### PR DESCRIPTION
In #79 I set up the particle filter state in a way that caused some unwanted object copies on modification (see https://github.com/r-lib/R6/issues/201). This PR backs that out and also adds a wrapper for running several steps of the particle filter, which tidies up the interface a bit more (and should help a little further with performance).

mcstate 0.4.3 shows a 4x slowdown for sircovid with history saving!

Fixes #103 