### PR TITLE
Remove deprecated arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.5.3
+Version: 0.5.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.5.4
+
+* Remove deprecated arguments to `pmcmc` (these were deprecated in 0.3.0) (#114)
+
 # mcstate 0.5.3
 
 * Bugfix in `index` for nested particle filters.

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -20,16 +20,6 @@
 ##'
 ##' @param filter A [`particle_filter`] object
 ##'
-##' @param n_steps Deprecated: use [mcstate::pmcmc_control] instead
-##'
-##' @param save_state Deprecated: use [mcstate::pmcmc_control] instead
-##'
-##' @param save_trajectories Deprecated: use [mcstate::pmcmc_control] instead
-##'
-##' @param progress Deprecated: use [mcstate::pmcmc_control] instead
-##'
-##' @param n_chains Deprecated: use [mcstate::pmcmc_control] instead
-##'
 ##' @param initial Optional initial starting point. If given, it must
 ##'   be compatible with the parameters given in `pars`, and must be
 ##'   valid against your prior. You can use this to override the
@@ -37,8 +27,6 @@
 ##'   either a vector of initial conditions, or a matrix with
 ##'   `n_chains` columns to use a different starting point for each
 ##'   chain.
-##'
-##' @param rerun_every Deprecated: use [mcstate::pmcmc_control] instead
 ##'
 ##' @param control A [mcstate::pmcmc_control] object which will set
 ##'   parameters. This will become the primary way of specifying
@@ -58,32 +46,10 @@
 ##'   simulation (if `return_trajectories` was `TRUE`).
 ##'
 ##' @export
-pmcmc <- function(pars, filter, n_steps, save_state = TRUE,
-                  save_trajectories = FALSE, progress = FALSE,
-                  n_chains = 1, initial = NULL, rerun_every = Inf,
-                  control = NULL) {
-
+pmcmc <- function(pars, filter, initial = NULL, control = NULL) {
   assert_is(pars, c("pmcmc_parameters", "pmcmc_parameters_nested"))
   assert_is(filter, "particle_filter")
-
-  if (is.null(control)) {
-    warning("Please update your code to use pmcmc::pmcmc_control()",
-            immediate. = TRUE)
-    control <- pmcmc_control(n_steps,
-                             n_chains = n_chains,
-                             rerun_every = rerun_every,
-                             save_state = save_state,
-                             save_trajectories = save_trajectories,
-                             progress = progress)
-  } else {
-    assert_is(control, "pmcmc_control")
-    ok <- missing(n_steps) && missing(save_state) &&
-      missing(save_trajectories) && missing(progress) && missing(n_chains) &&
-      missing(rerun_every)
-    if (!ok) {
-      stop("Do not use deprecated arguments duplicated in pmcmc_control")
-    }
-  }
+  assert_is(control, "pmcmc_control")
 
   if (inherits(pars, "pmcmc_parameters_nested")) {
     initial <- pmcmc_check_initial_nested(initial, pars, control$n_chains)

--- a/man/pmcmc.Rd
+++ b/man/pmcmc.Rd
@@ -4,18 +4,7 @@
 \alias{pmcmc}
 \title{Run a pmcmc sampler}
 \usage{
-pmcmc(
-  pars,
-  filter,
-  n_steps,
-  save_state = TRUE,
-  save_trajectories = FALSE,
-  progress = FALSE,
-  n_chains = 1,
-  initial = NULL,
-  rerun_every = Inf,
-  control = NULL
-)
+pmcmc(pars, filter, initial = NULL, control = NULL)
 }
 \arguments{
 \item{pars}{A \code{\link{pmcmc_parameters}} object containing
@@ -24,16 +13,6 @@ translation functions for use with the particle filter).}
 
 \item{filter}{A \code{\link{particle_filter}} object}
 
-\item{n_steps}{Deprecated: use \link{pmcmc_control} instead}
-
-\item{save_state}{Deprecated: use \link{pmcmc_control} instead}
-
-\item{save_trajectories}{Deprecated: use \link{pmcmc_control} instead}
-
-\item{progress}{Deprecated: use \link{pmcmc_control} instead}
-
-\item{n_chains}{Deprecated: use \link{pmcmc_control} instead}
-
 \item{initial}{Optional initial starting point. If given, it must
 be compatible with the parameters given in \code{pars}, and must be
 valid against your prior. You can use this to override the
@@ -41,8 +20,6 @@ initial conditions saved in your \code{pars} object. You can provide
 either a vector of initial conditions, or a matrix with
 \code{n_chains} columns to use a different starting point for each
 chain.}
-
-\item{rerun_every}{Deprecated: use \link{pmcmc_control} instead}
 
 \item{control}{A \link{pmcmc_control} object which will set
 parameters. This will become the primary way of specifying

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -459,19 +459,6 @@ test_that("can change the number of threads mid-run", {
 })
 
 
-test_that("Warn if using deprecated interface", {
-  dat <- example_uniform()
-  expect_warning(
-    pmcmc(dat$pars, dat$filter, 100, save_state = FALSE),
-    "Please update your code to use pmcmc::pmcmc_control()",
-    fixed = TRUE)
-  expect_error(
-    pmcmc(dat$pars, dat$filter, progress = TRUE,
-          control = pmcmc_control(100, save_state = FALSE)),
-    "Do not use deprecated arguments duplicated in pmcmc_control")
-})
-
-
 test_that("Can override thread count via control", {
   dat <- example_sir()
   n_particles <- 30


### PR DESCRIPTION
these arguments were removed in 0.3.0 and are no longer referenced in our work. 

Fixes #114