### PR TITLE
Nested step ratio

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.5.8
+Version: 0.5.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # mcstate 0.5.9
 
-* Add `nested_step_ratio` parameter to `pmcmc_control` for controlling the ratio of fixed:varied
-steps for nested pMCMC
+* Add `nested_step_ratio` parameter to `pmcmc_control` for controlling the ratio of fixed:varied steps for nested pMCMC
 
 # mcstate 0.5.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# mcstate 0.5.9
+
+* Add parameter to `pmcmc_control` for controlling the ratio of fixed:varied
+steps for nested pMCMC
+
 # mcstate 0.5.5
 
 * New array helper `mcstate::array_flatten` for unshaping an array

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mcstate 0.5.9
 
-* Add parameter to `pmcmc_control` for controlling the ratio of fixed:varied
+* Add `nested_step_ratio` parameter to `pmcmc_control` for controlling the ratio of fixed:varied
 steps for nested pMCMC
 
 # mcstate 0.5.5

--- a/R/pmcmc_control.R
+++ b/R/pmcmc_control.R
@@ -153,34 +153,34 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
         n_threads_total, n_workers))
     }
   }
-  
+
   if (!identical(unname(rerun_every), Inf)) {
     assert_scalar_positive_integer(rerun_every)
-    
+
   }
-  
+
   assert_scalar_logical(use_parallel_seed)
   assert_scalar_logical(save_state)
   assert_scalar_logical(save_trajectories)
   assert_scalar_logical(progress)
-  
+
   if (n_chains < n_workers) {
     stop(sprintf("'n_chains' (%d) is less than 'n_workers' (%d)",
                  n_chains, n_workers))
   }
-  
+
   if (!is.null(save_restart)) {
     ## possibly assert_integer(save_restart)?
     assert_strictly_increasing(save_restart)
   }
-  
+
   nok <- !test_integer(nested_step_ratio) &&
     !test_integer(1 / nested_step_ratio)
   if (nok) {
     stop(sprintf("Either 'nested_step_ratio' (%g) or 1/'nested_step_ratio'
                           must be an integer", nested_step_ratio))
   }
-  
+
   ret <- list(n_steps = n_steps,
               n_chains = n_chains,
               n_workers = n_workers,

--- a/R/pmcmc_control.R
+++ b/R/pmcmc_control.R
@@ -103,7 +103,11 @@
 ##'   ratio of fixed:varied steps in a nested pMCMC. For example `3` would run
 ##'   3 steps proposing fixed parameters only and then 1 step proposing varied
 ##'   parameters only; whereas `1/3` would run 3 varied steps
-##'   for every 1 fixed step.
+##'   for every 1 fixed step. The default value of `1` runs an equal number of
+##'   iterations updating the fixed and varied parameters. Sensible choices
+##'   of this parameter may depend on the true ratio of fixed:varied parameters
+##'   or on desired run-time, for example updating fixed parameters is
+##'   quicker so more varied steps could be more efficient.
 ##'
 ##' @return A `pmcmc_control` object, which should not be modified
 ##'   once created.

--- a/R/pmcmc_control.R
+++ b/R/pmcmc_control.R
@@ -102,7 +102,7 @@
 ##' @param nested_step_ratio Either integer or 1/integer, which specifies the
 ##'   ratio of fixed:varied steps in a nested pMCMC. For example `3` would run
 ##'   3 steps proposing fixed parameters only and then 1 step proposing varied
-##'   parameters only; whereas whereas `1/3` would run 3 varied steps
+##'   parameters only; whereas `1/3` would run 3 varied steps
 ##'   for every 1 fixed step.
 ##'
 ##' @return A `pmcmc_control` object, which should not be modified

--- a/R/pmcmc_state.R
+++ b/R/pmcmc_state.R
@@ -1,17 +1,17 @@
 pmcmc_state <- R6::R6Class(
   "pmcmc_state",
-
+  
   private = list(
     filter = NULL,
     pars = NULL,
     control = NULL,
-
+    
     history_pars = NULL,
     history_probabilities = NULL,
     history_state = NULL,
     history_restart = NULL,
     history_trajectories = NULL,
-
+    
     curr_step = NULL,
     curr_pars = NULL,
     curr_lprior = NULL,
@@ -20,9 +20,9 @@ pmcmc_state <- R6::R6Class(
     curr_trajectories = NULL,
     curr_state = NULL,
     curr_restart = NULL,
-
+    
     tick = NULL,
-
+    
     update_history = function() {
       i <- sample.int(private$filter$n_particles, 1)
       if (private$control$save_trajectories) {
@@ -37,7 +37,7 @@ pmcmc_state <- R6::R6Class(
         dim(private$curr_restart) <- dim(private$curr_restart)[-2L]
       }
     },
-
+    
     update_history_nested = function() {
       i <- sample.int(private$filter$n_particles, 1)
       if (private$control$save_trajectories) {
@@ -55,27 +55,27 @@ pmcmc_state <- R6::R6Class(
         dim(private$curr_restart) <- dim(private$curr_restart)[-2L]
       }
     },
-
+    
     run_filter = function(p) {
       private$filter$run(private$pars$model(p),
                          private$control$save_trajectories,
                          private$control$save_restart)
     },
-
+    
     run_filter_nested = function(p) {
       private$filter$run(private$pars$model(p),
                          private$control$save_trajectories,
                          private$control$save_restart)
     },
-
-
+    
+    
     run_fixed = function() {
       if (length(r6_private(private$pars)$fixed_parameters) > 0) {
         prop_pars <- private$pars$propose(private$curr_pars, type = "fixed")
         prop_lprior <- private$pars$prior(prop_pars)
         prop_llik <- private$run_filter_nested(prop_pars)
         prop_lpost <- prop_lprior + prop_llik
-
+        
         if (runif(1) < exp(sum(prop_lpost) - sum(private$curr_lpost))) {
           private$curr_pars <- prop_pars
           private$curr_lprior <- prop_lprior
@@ -85,14 +85,14 @@ pmcmc_state <- R6::R6Class(
         }
       }
     },
-
+    
     run_varied = function() {
       if (length(r6_private(private$pars)$varied_parameters) > 0) {
         prop_pars <- private$pars$propose(private$curr_pars, type = "varied")
         prop_lprior <- private$pars$prior(prop_pars)
         prop_llik <- private$run_filter_nested(prop_pars)
         prop_lpost <- prop_lprior + prop_llik
-
+        
         which <- runif(length(prop_lpost)) <
           exp(prop_lpost - private$curr_lpost)
         if (any(which)) {
@@ -105,25 +105,25 @@ pmcmc_state <- R6::R6Class(
       }
     }
   ),
-
+  
   public = list(
     initialize = function(pars, initial, filter, control) {
       private$filter <- filter
       private$pars <- pars
       private$control <- control
-
+      
       private$history_pars <- history_collector(control$n_steps)
       private$history_probabilities <- history_collector(control$n_steps)
       private$history_state <- history_collector(control$n_steps)
       private$history_restart <- history_collector(control$n_steps)
       private$history_trajectories <- history_collector(control$n_steps)
-
+      
       private$curr_step <- 0L
       private$curr_pars <- initial
       private$curr_lprior <- private$pars$prior(private$curr_pars)
-
+      
       private$tick <- pmcmc_progress(control$n_steps, control$progress)
-
+      
       private$history_pars$add(private$curr_pars)
       if (inherits(pars, "pmcmc_parameters_nested")) {
         private$curr_llik <- private$run_filter_nested(private$curr_pars)
@@ -140,11 +140,11 @@ pmcmc_state <- R6::R6Class(
                                             private$curr_lpost))
         private$update_history()
       }
-
-
-
+      
+      
+      
       ## Initial version of the history
-
+      
       if (private$control$save_trajectories) {
         private$history_trajectories$add(private$curr_trajectories)
       }
@@ -155,11 +155,11 @@ pmcmc_state <- R6::R6Class(
         private$history_restart$add(private$curr_restart)
       }
     },
-
+    
     set_n_threads = function(n_threads) {
       private$filter$set_n_threads(n_threads)
     },
-
+    
     run = function() {
       to <- min(private$curr_step + private$control$n_steps_each,
                 private$control$n_steps)
@@ -167,18 +167,18 @@ pmcmc_state <- R6::R6Class(
                    length.out = to - private$curr_step)
       for (i in steps) {
         private$tick()
-
+        
         if (i %% private$control$rerun_every == 0) {
           private$curr_llik <- private$run_filter(private$curr_pars)
           private$curr_lpost <- private$curr_lprior + private$curr_llik
           private$update_history()
         }
-
+        
         prop_pars <- private$pars$propose(private$curr_pars)
         prop_lprior <- private$pars$prior(prop_pars)
         prop_llik <- private$run_filter(prop_pars)
         prop_lpost <- prop_lprior + prop_llik
-
+        
         if (runif(1) < exp(prop_lpost - private$curr_lpost)) {
           private$curr_pars <- prop_pars
           private$curr_lprior <- prop_lprior
@@ -186,11 +186,11 @@ pmcmc_state <- R6::R6Class(
           private$curr_lpost <- prop_lpost
           private$update_history()
         }
-
+        
         private$history_pars$add(private$curr_pars)
         private$history_probabilities$add(
           c(private$curr_lprior, private$curr_llik, private$curr_lpost))
-
+        
         if (private$control$save_trajectories) {
           private$history_trajectories$add(private$curr_trajectories)
         }
@@ -204,33 +204,51 @@ pmcmc_state <- R6::R6Class(
       private$curr_step <- to
       list(step = to, finished = to == private$control$n_steps)
     },
-
+    
     run_nested = function() {
       to <- min(private$curr_step + private$control$n_steps_each,
                 private$control$n_steps)
       steps <- seq(from = private$curr_step + 1L,
                    length.out = to - private$curr_step)
-
+      
+      fix_vary_step <- vary_fix_step <- NULL
+      if (test_integer(private$control$nested_step_ratio)) {
+        fix_vary_step <- round(private$control$nested_step_ratio) + 1
+      } else {
+        vary_fix_step <- round(1 / private$control$nested_step_ratio) + 1
+      }
+      
+      ## add linear counter for step ratio
+      j <- 1
       for (i in steps) {
         private$tick()
-
+        
         if (i %% private$control$rerun_every == 0) {
           private$curr_llik <- private$run_filter_nested(private$curr_pars)
           private$curr_lpost <- private$curr_lprior + private$curr_llik
           private$update_history_nested()
         }
-
-        if (i %% 2) {
-          private$run_fixed()
+        
+        if (!is.null(fix_vary_step)) {
+          if (j %% fix_vary_step > 0) {
+            private$run_fixed()
+          } else {
+            private$run_varied()
+          }
         } else {
-          private$run_varied()
+          if (j %% vary_fix_step > 0) {
+            private$run_varied()
+          } else {
+            private$run_fixed()
+          }
         }
-
+        j <- j + 1
+        
         private$history_pars$add(private$curr_pars)
         private$history_probabilities$add(
           matrix(c(private$curr_lprior, private$curr_llik, private$curr_lpost),
                  ncol = 3, byrow = TRUE))
-
+        
         if (private$control$save_trajectories) {
           private$history_trajectories$add(private$curr_trajectories)
         }
@@ -240,21 +258,21 @@ pmcmc_state <- R6::R6Class(
         if (length(private$control$save_restart) > 0) {
           private$history_restart$add(private$curr_restart)
         }
-
+        
       }
       private$curr_step <- to
       list(step = to, finished = to == private$control$n_steps)
     },
-
+    
     finish = function() {
       pars_matrix <- set_colnames(list_to_matrix(private$history_pars$get()),
                                   names(private$curr_pars))
       probabilities <- set_colnames(
         list_to_matrix(private$history_probabilities$get()),
         c("log_prior", "log_likelihood", "log_posterior"))
-
+      
       predict <- state <- restart <- trajectories <- NULL
-
+      
       if (private$control$save_state || private$control$save_trajectories) {
         ## Do we *definitely* need step and rate here?
         data <- private$filter$inputs()$data
@@ -264,11 +282,11 @@ pmcmc_state <- R6::R6Class(
                         rate = attr(data, "rate", exact = TRUE),
                         filter = private$filter$inputs())
       }
-
+      
       if (private$control$save_state) {
         state <- t(list_to_matrix(private$history_state$get()))
       }
-
+      
       if (length(private$control$save_restart) > 0) {
         ## Permute state from [state x save point x mcmc_sample]
         ## to [state x mcmc_sample x save point] to match the predicted state)
@@ -277,7 +295,7 @@ pmcmc_state <- R6::R6Class(
         restart <- list(time = private$control$save_restart,
                         state = restart_state)
       }
-
+      
       if (private$control$save_trajectories) {
         ## Permute trajectories from [state x mcmc x particle] to
         ## [state x particle x mcmc] so that they match the ones that we
@@ -290,26 +308,26 @@ pmcmc_state <- R6::R6Class(
         trajectories <- mcstate_trajectories(step, predict$rate,
                                              trajectories_state, FALSE)
       }
-
+      
       mcstate_pmcmc(pars_matrix, probabilities, state, trajectories, restart,
                     predict)
     },
-
+    
     finish_nested = function() {
       ## param x pop x step
       pars_array <- list_to_array(private$history_pars$get())
       pars_array <- aperm(pars_array, c(2, 1, 3))
       dimnames(pars_array)[c(2, 1)] <- dimnames(private$curr_pars)
-
+      
       ## var x pop x step
       probabilities <- list_to_array(private$history_probabilities$get())
       probabilities <- aperm(probabilities, c(2, 1, 3))
       dimnames(probabilities)[1:2] <- list(c("log_prior", "log_likelihood",
                                              "log_posterior"),
                                            rownames(private$curr_pars))
-
+      
       predict <- state <- restart <- trajectories <- NULL
-
+      
       if (private$control$save_state || private$control$save_trajectories) {
         data <- private$filter$inputs()$data
         predict <- list(transform = r6_private(private$pars)$transform,
@@ -318,13 +336,13 @@ pmcmc_state <- R6::R6Class(
                         rate = attr(data, "rate", exact = TRUE),
                         filter = private$filter$inputs())
       }
-
+      
       if (private$control$save_state) {
         # [state x pop x step]
         state <- list_to_array(private$history_state$get())
         colnames(state) <- rownames(private$curr_pars)
       }
-
+      
       if (length(private$control$save_restart) > 0) {
         ## [state x sample x pop x time]
         restart_state  <-
@@ -332,21 +350,21 @@ pmcmc_state <- R6::R6Class(
         restart <- list(time = private$control$save_restart,
                         state = restart_state)
       }
-
+      
       if (private$control$save_trajectories) {
         ## [state x particle x population x step]
         trajectories_state <-
           list_to_array(private$history_trajectories$get())
         trajectories_state <- aperm(trajectories_state, c(1, 4, 2, 3))
         rownames(trajectories_state) <- names(predict$index)
-
+        
         data <- private$filter$inputs()$data
         step_end <- data$step_end[seq_len(tabulate(data$population)[1])]
         step <- c(data$step_start[[1]], step_end)
         trajectories <- mcstate_trajectories(step, predict$rate,
                                              trajectories_state, FALSE)
       }
-
+      
       mcstate_pmcmc(pars_array, probabilities, state, trajectories, restart,
                     predict)
     }
@@ -387,10 +405,10 @@ history_collector <- function(n) {
     i <<- i + 1L
     data[[i]] <<- value
   }
-
+  
   get <- function() {
     data
   }
-
+  
   list(add = add, get = get)
 }

--- a/R/pmcmc_state.R
+++ b/R/pmcmc_state.R
@@ -1,17 +1,17 @@
 pmcmc_state <- R6::R6Class(
   "pmcmc_state",
-  
+
   private = list(
     filter = NULL,
     pars = NULL,
     control = NULL,
-    
+
     history_pars = NULL,
     history_probabilities = NULL,
     history_state = NULL,
     history_restart = NULL,
     history_trajectories = NULL,
-    
+
     curr_step = NULL,
     curr_pars = NULL,
     curr_lprior = NULL,
@@ -20,9 +20,9 @@ pmcmc_state <- R6::R6Class(
     curr_trajectories = NULL,
     curr_state = NULL,
     curr_restart = NULL,
-    
+
     tick = NULL,
-    
+
     update_history = function() {
       i <- sample.int(private$filter$n_particles, 1)
       if (private$control$save_trajectories) {
@@ -37,7 +37,7 @@ pmcmc_state <- R6::R6Class(
         dim(private$curr_restart) <- dim(private$curr_restart)[-2L]
       }
     },
-    
+
     update_history_nested = function() {
       i <- sample.int(private$filter$n_particles, 1)
       if (private$control$save_trajectories) {
@@ -55,27 +55,27 @@ pmcmc_state <- R6::R6Class(
         dim(private$curr_restart) <- dim(private$curr_restart)[-2L]
       }
     },
-    
+
     run_filter = function(p) {
       private$filter$run(private$pars$model(p),
                          private$control$save_trajectories,
                          private$control$save_restart)
     },
-    
+
     run_filter_nested = function(p) {
       private$filter$run(private$pars$model(p),
                          private$control$save_trajectories,
                          private$control$save_restart)
     },
-    
-    
+
+
     run_fixed = function() {
       if (length(r6_private(private$pars)$fixed_parameters) > 0) {
         prop_pars <- private$pars$propose(private$curr_pars, type = "fixed")
         prop_lprior <- private$pars$prior(prop_pars)
         prop_llik <- private$run_filter_nested(prop_pars)
         prop_lpost <- prop_lprior + prop_llik
-        
+
         if (runif(1) < exp(sum(prop_lpost) - sum(private$curr_lpost))) {
           private$curr_pars <- prop_pars
           private$curr_lprior <- prop_lprior
@@ -85,14 +85,14 @@ pmcmc_state <- R6::R6Class(
         }
       }
     },
-    
+
     run_varied = function() {
       if (length(r6_private(private$pars)$varied_parameters) > 0) {
         prop_pars <- private$pars$propose(private$curr_pars, type = "varied")
         prop_lprior <- private$pars$prior(prop_pars)
         prop_llik <- private$run_filter_nested(prop_pars)
         prop_lpost <- prop_lprior + prop_llik
-        
+
         which <- runif(length(prop_lpost)) <
           exp(prop_lpost - private$curr_lpost)
         if (any(which)) {
@@ -105,25 +105,25 @@ pmcmc_state <- R6::R6Class(
       }
     }
   ),
-  
+
   public = list(
     initialize = function(pars, initial, filter, control) {
       private$filter <- filter
       private$pars <- pars
       private$control <- control
-      
+
       private$history_pars <- history_collector(control$n_steps)
       private$history_probabilities <- history_collector(control$n_steps)
       private$history_state <- history_collector(control$n_steps)
       private$history_restart <- history_collector(control$n_steps)
       private$history_trajectories <- history_collector(control$n_steps)
-      
+
       private$curr_step <- 0L
       private$curr_pars <- initial
       private$curr_lprior <- private$pars$prior(private$curr_pars)
-      
+
       private$tick <- pmcmc_progress(control$n_steps, control$progress)
-      
+
       private$history_pars$add(private$curr_pars)
       if (inherits(pars, "pmcmc_parameters_nested")) {
         private$curr_llik <- private$run_filter_nested(private$curr_pars)
@@ -140,11 +140,11 @@ pmcmc_state <- R6::R6Class(
                                             private$curr_lpost))
         private$update_history()
       }
-      
-      
-      
+
+
+
       ## Initial version of the history
-      
+
       if (private$control$save_trajectories) {
         private$history_trajectories$add(private$curr_trajectories)
       }
@@ -155,11 +155,11 @@ pmcmc_state <- R6::R6Class(
         private$history_restart$add(private$curr_restart)
       }
     },
-    
+
     set_n_threads = function(n_threads) {
       private$filter$set_n_threads(n_threads)
     },
-    
+
     run = function() {
       to <- min(private$curr_step + private$control$n_steps_each,
                 private$control$n_steps)
@@ -167,18 +167,18 @@ pmcmc_state <- R6::R6Class(
                    length.out = to - private$curr_step)
       for (i in steps) {
         private$tick()
-        
+
         if (i %% private$control$rerun_every == 0) {
           private$curr_llik <- private$run_filter(private$curr_pars)
           private$curr_lpost <- private$curr_lprior + private$curr_llik
           private$update_history()
         }
-        
+
         prop_pars <- private$pars$propose(private$curr_pars)
         prop_lprior <- private$pars$prior(prop_pars)
         prop_llik <- private$run_filter(prop_pars)
         prop_lpost <- prop_lprior + prop_llik
-        
+
         if (runif(1) < exp(prop_lpost - private$curr_lpost)) {
           private$curr_pars <- prop_pars
           private$curr_lprior <- prop_lprior
@@ -186,11 +186,11 @@ pmcmc_state <- R6::R6Class(
           private$curr_lpost <- prop_lpost
           private$update_history()
         }
-        
+
         private$history_pars$add(private$curr_pars)
         private$history_probabilities$add(
           c(private$curr_lprior, private$curr_llik, private$curr_lpost))
-        
+
         if (private$control$save_trajectories) {
           private$history_trajectories$add(private$curr_trajectories)
         }
@@ -204,31 +204,31 @@ pmcmc_state <- R6::R6Class(
       private$curr_step <- to
       list(step = to, finished = to == private$control$n_steps)
     },
-    
+
     run_nested = function() {
       to <- min(private$curr_step + private$control$n_steps_each,
                 private$control$n_steps)
       steps <- seq(from = private$curr_step + 1L,
                    length.out = to - private$curr_step)
-      
+
       fix_vary_step <- vary_fix_step <- NULL
       if (test_integer(private$control$nested_step_ratio)) {
         fix_vary_step <- round(private$control$nested_step_ratio) + 1
       } else {
         vary_fix_step <- round(1 / private$control$nested_step_ratio) + 1
       }
-      
+
       ## add linear counter for step ratio
       j <- 1
       for (i in steps) {
         private$tick()
-        
+
         if (i %% private$control$rerun_every == 0) {
           private$curr_llik <- private$run_filter_nested(private$curr_pars)
           private$curr_lpost <- private$curr_lprior + private$curr_llik
           private$update_history_nested()
         }
-        
+
         if (!is.null(fix_vary_step)) {
           if (j %% fix_vary_step > 0) {
             private$run_fixed()
@@ -243,12 +243,12 @@ pmcmc_state <- R6::R6Class(
           }
         }
         j <- j + 1
-        
+
         private$history_pars$add(private$curr_pars)
         private$history_probabilities$add(
           matrix(c(private$curr_lprior, private$curr_llik, private$curr_lpost),
                  ncol = 3, byrow = TRUE))
-        
+
         if (private$control$save_trajectories) {
           private$history_trajectories$add(private$curr_trajectories)
         }
@@ -258,21 +258,21 @@ pmcmc_state <- R6::R6Class(
         if (length(private$control$save_restart) > 0) {
           private$history_restart$add(private$curr_restart)
         }
-        
+
       }
       private$curr_step <- to
       list(step = to, finished = to == private$control$n_steps)
     },
-    
+
     finish = function() {
       pars_matrix <- set_colnames(list_to_matrix(private$history_pars$get()),
                                   names(private$curr_pars))
       probabilities <- set_colnames(
         list_to_matrix(private$history_probabilities$get()),
         c("log_prior", "log_likelihood", "log_posterior"))
-      
+
       predict <- state <- restart <- trajectories <- NULL
-      
+
       if (private$control$save_state || private$control$save_trajectories) {
         ## Do we *definitely* need step and rate here?
         data <- private$filter$inputs()$data
@@ -282,11 +282,11 @@ pmcmc_state <- R6::R6Class(
                         rate = attr(data, "rate", exact = TRUE),
                         filter = private$filter$inputs())
       }
-      
+
       if (private$control$save_state) {
         state <- t(list_to_matrix(private$history_state$get()))
       }
-      
+
       if (length(private$control$save_restart) > 0) {
         ## Permute state from [state x save point x mcmc_sample]
         ## to [state x mcmc_sample x save point] to match the predicted state)
@@ -295,7 +295,7 @@ pmcmc_state <- R6::R6Class(
         restart <- list(time = private$control$save_restart,
                         state = restart_state)
       }
-      
+
       if (private$control$save_trajectories) {
         ## Permute trajectories from [state x mcmc x particle] to
         ## [state x particle x mcmc] so that they match the ones that we
@@ -308,26 +308,26 @@ pmcmc_state <- R6::R6Class(
         trajectories <- mcstate_trajectories(step, predict$rate,
                                              trajectories_state, FALSE)
       }
-      
+
       mcstate_pmcmc(pars_matrix, probabilities, state, trajectories, restart,
                     predict)
     },
-    
+
     finish_nested = function() {
       ## param x pop x step
       pars_array <- list_to_array(private$history_pars$get())
       pars_array <- aperm(pars_array, c(2, 1, 3))
       dimnames(pars_array)[c(2, 1)] <- dimnames(private$curr_pars)
-      
+
       ## var x pop x step
       probabilities <- list_to_array(private$history_probabilities$get())
       probabilities <- aperm(probabilities, c(2, 1, 3))
       dimnames(probabilities)[1:2] <- list(c("log_prior", "log_likelihood",
                                              "log_posterior"),
                                            rownames(private$curr_pars))
-      
+
       predict <- state <- restart <- trajectories <- NULL
-      
+
       if (private$control$save_state || private$control$save_trajectories) {
         data <- private$filter$inputs()$data
         predict <- list(transform = r6_private(private$pars)$transform,
@@ -336,13 +336,13 @@ pmcmc_state <- R6::R6Class(
                         rate = attr(data, "rate", exact = TRUE),
                         filter = private$filter$inputs())
       }
-      
+
       if (private$control$save_state) {
         # [state x pop x step]
         state <- list_to_array(private$history_state$get())
         colnames(state) <- rownames(private$curr_pars)
       }
-      
+
       if (length(private$control$save_restart) > 0) {
         ## [state x sample x pop x time]
         restart_state  <-
@@ -350,21 +350,21 @@ pmcmc_state <- R6::R6Class(
         restart <- list(time = private$control$save_restart,
                         state = restart_state)
       }
-      
+
       if (private$control$save_trajectories) {
         ## [state x particle x population x step]
         trajectories_state <-
           list_to_array(private$history_trajectories$get())
         trajectories_state <- aperm(trajectories_state, c(1, 4, 2, 3))
         rownames(trajectories_state) <- names(predict$index)
-        
+
         data <- private$filter$inputs()$data
         step_end <- data$step_end[seq_len(tabulate(data$population)[1])]
         step <- c(data$step_start[[1]], step_end)
         trajectories <- mcstate_trajectories(step, predict$rate,
                                              trajectories_state, FALSE)
       }
-      
+
       mcstate_pmcmc(pars_array, probabilities, state, trajectories, restart,
                     predict)
     }
@@ -405,10 +405,10 @@ history_collector <- function(n) {
     i <<- i + 1L
     data[[i]] <<- value
   }
-  
+
   get <- function() {
     data
   }
-  
+
   list(add = add, get = get)
 }

--- a/R/pmcmc_state.R
+++ b/R/pmcmc_state.R
@@ -214,8 +214,6 @@ pmcmc_state <- R6::R6Class(
       run_alternate_step <- alternate(private$run_fixed, private$run_varied,
                                       private$control$nested_step_ratio)
 
-      ## add linear counter for step ratio
-      j <- 1
       for (i in steps) {
         private$tick()
 
@@ -225,8 +223,7 @@ pmcmc_state <- R6::R6Class(
           private$update_history_nested()
         }
 
-        run_alternate_step(j)
-        j <- j + 1
+        run_alternate_step(i)
 
         private$history_pars$add(private$curr_pars)
         private$history_probabilities$add(

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,7 +45,7 @@ rmvnorm_generator <- function(vcv) {
   }
   n <- nrow(vcv)
   res <- t(ev$vectors %*% (t(ev$vectors) * sqrt(pmax(ev$values, 0))))
-  
+
   function(mean, scale = 1.0) {
     mean + drop(rnorm(ncol(vcv)) %*% (res * sqrt(scale)))
   }
@@ -66,7 +66,7 @@ list_to_array <- function(data) {
     which <- len > 0
     len <- len[which]
     stopifnot(length(unique(len)) == 1)
-    
+
     data <- data[which]
     array(unlist(data, FALSE, FALSE), c(dim(data[[1L]]), length(data)))
   }
@@ -176,22 +176,22 @@ layernames <- function(x) {
   if (length(dim(x)) < 3) {
     stop("'x' has less than three dimensions")
   }
-  
+
   nms <- dimnames(x)
-  
+
   if (is.null(nms)) {
     if (is.null(value)) {
       stop("'value' cannot be NULL if 'dimnames(x)' is NULL")
     }
     nms <- vector("list", length(dim(x)))
   }
-  
+
   if (is.null(value)) {
     nms[3L] <- list(NULL)
   } else {
     nms[[3L]] <-  assert_scalar_character(value)
   }
-  
+
   dimnames(x) <- nms
   x
 }
@@ -221,6 +221,6 @@ test_integer <- function(x, name = deparse(substitute(x)),
       return(FALSE)
     }
   }
-  
+
   TRUE
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,7 +45,7 @@ rmvnorm_generator <- function(vcv) {
   }
   n <- nrow(vcv)
   res <- t(ev$vectors %*% (t(ev$vectors) * sqrt(pmax(ev$values, 0))))
-
+  
   function(mean, scale = 1.0) {
     mean + drop(rnorm(ncol(vcv)) %*% (res * sqrt(scale)))
   }
@@ -66,7 +66,7 @@ list_to_array <- function(data) {
     which <- len > 0
     len <- len[which]
     stopifnot(length(unique(len)) == 1)
-
+    
     data <- data[which]
     array(unlist(data, FALSE, FALSE), c(dim(data[[1L]]), length(data)))
   }
@@ -176,22 +176,22 @@ layernames <- function(x) {
   if (length(dim(x)) < 3) {
     stop("'x' has less than three dimensions")
   }
-
+  
   nms <- dimnames(x)
-
+  
   if (is.null(nms)) {
     if (is.null(value)) {
       stop("'value' cannot be NULL if 'dimnames(x)' is NULL")
     }
     nms <- vector("list", length(dim(x)))
   }
-
+  
   if (is.null(value)) {
     nms[3L] <- list(NULL)
   } else {
     nms[[3L]] <-  assert_scalar_character(value)
   }
-
+  
   dimnames(x) <- nms
   x
 }
@@ -209,4 +209,18 @@ normalise <- function(x) {
 
 try_list_get <- function(list, nm) {
   tryCatch(list[[nm]], error = function(e) NULL)
+}
+
+
+test_integer <- function(x, name = deparse(substitute(x)),
+                         what = "integer") {
+  if (!(is.integer(x))) {
+    eps <- sqrt(.Machine$double.eps)
+    usable_as_integer <- is.numeric(x) && (max(abs(round(x) - x)) < eps)
+    if (!usable_as_integer) {
+      return(FALSE)
+    }
+  }
+  
+  TRUE
 }

--- a/man/pmcmc_control.Rd
+++ b/man/pmcmc_control.Rd
@@ -112,7 +112,11 @@ displayed, using \code{\link[progress:progress_bar]{progress::progress_bar}}.}
 ratio of fixed:varied steps in a nested pMCMC. For example \code{3} would run
 3 steps proposing fixed parameters only and then 1 step proposing varied
 parameters only; whereas \code{1/3} would run 3 varied steps
-for every 1 fixed step.}
+for every 1 fixed step. The default value of \code{1} runs an equal number of
+iterations updating the fixed and varied parameters. Sensible choices
+of this parameter may depend on the true ratio of fixed:varied parameters
+or on desired run-time, for example updating fixed parameters is
+quicker so more varied steps could be more efficient.}
 }
 \value{
 A \code{pmcmc_control} object, which should not be modified

--- a/man/pmcmc_control.Rd
+++ b/man/pmcmc_control.Rd
@@ -15,7 +15,8 @@ pmcmc_control(
   save_state = TRUE,
   save_restart = NULL,
   save_trajectories = FALSE,
-  progress = FALSE
+  progress = FALSE,
+  nested_step_ratio = 1
 )
 }
 \arguments{
@@ -106,6 +107,12 @@ particle will be selected for each.}
 
 \item{progress}{Logical, indicating if a progress bar should be
 displayed, using \code{\link[progress:progress_bar]{progress::progress_bar}}.}
+
+\item{nested_step_ratio}{Either integer or 1/integer, which specifies the
+ratio of fixed:varied steps in a nested pMCMC. For example \code{3} would run
+3 steps proposing fixed parameters only and then 1 step proposing varied
+parameters only; whereas \code{1/3} would run 3 varied steps
+for every 1 fixed step.}
 }
 \value{
 A \code{pmcmc_control} object, which should not be modified

--- a/tests/testthat/test-pmcmc-control.R
+++ b/tests/testthat/test-pmcmc-control.R
@@ -47,3 +47,10 @@ test_that("specify save_restart", {
     pmcmc_control(100, save_restart = c(20, 10)),
     "'save_restart' must be strictly increasing")
 })
+
+test_that("integer step ratio", {
+  expect_error(pmcmc_control(1, nested_step_ratio = 1.2), "must be an integer")
+  expect_error(pmcmc_control(1, nested_step_ratio = 1 / 1.2), "must be")
+  expect_silent(pmcmc_control(1, nested_step_ratio = 3))
+  expect_silent(pmcmc_control(1, nested_step_ratio = 1 / 3))
+})

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -937,4 +937,10 @@ test_that("nested_step_ratio works", {
   res2 <- pmcmc(pars, p, control = control)
   expect_equal(as.numeric(res2$pars[2, , ]), rep(0.1, 62))
   expect_false(identical(as.numeric(res2$pars[1, , ]), rep(c(0.2, 0.3), 31)))
+
+  control <- pmcmc_control(30, nested_step_ratio = 1 / 2)
+  expect_is(pmcmc(pars, p, control = control), "mcstate_pmcmc")
+
+  control <- pmcmc_control(30, nested_step_ratio = 2)
+  expect_is(pmcmc(pars, p, control = control), "mcstate_pmcmc")
 })

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -7,7 +7,7 @@ context("pmcmc")
 test_that("mcmc works for uniform distribution on unit square", {
   dat <- example_uniform()
   control <- pmcmc_control(1000, save_state = FALSE, save_trajectories = FALSE)
-  
+
   set.seed(1)
   testthat::try_again(5, {
     res <- pmcmc(dat$pars, dat$filter, control = control)
@@ -22,7 +22,7 @@ test_that("mcmc works for uniform distribution on unit square", {
 test_that("mcmc works for multivariate gaussian", {
   dat <- example_mvnorm()
   control <- pmcmc_control(1000, save_state = FALSE, save_trajectories = FALSE)
-  
+
   set.seed(1)
   testthat::try_again(5, {
     res <- pmcmc(dat$pars, dat$filter, control = control)
@@ -39,12 +39,12 @@ test_that("Reflect parameters: double sided", {
   expect_equal(reflect_proposal(0.4, 0, 1), 0.4)
   expect_equal(reflect_proposal(1.4, 0, 1), 0.6)
   expect_equal(reflect_proposal(2.4, 0, 1), 0.4)
-  
+
   ## Additional cases from the original
   expect_equal(reflect_proposal(6, 1, 5), 4)
   expect_equal(reflect_proposal(0, 1, 5), 2)
   expect_equal(reflect_proposal(10, 1, 5), 2)
-  
+
   expect_equal(reflect_proposal(0:2 + 0.4, rep(0, 3), rep(1, 3)),
                c(0.4, 0.6, 0.4))
   expect_equal(reflect_proposal(0:2 + 1.4, rep(1, 3), rep(2, 3)),
@@ -76,7 +76,7 @@ test_that("proposal uses provided covariance structure", {
   dat <- example_uniform(proposal_kernel = matrix(0.1, 2, 2))
   control <- pmcmc_control(100, save_state = FALSE, save_trajectories = FALSE)
   res <- pmcmc(dat$pars, dat$filter, control = control)
-  
+
   expect_true(all(acceptance_rate(res$pars) == 1))
   expect_equal(res$pars[, 1], res$pars[, 2])
 })
@@ -85,56 +85,56 @@ test_that("proposal uses provided covariance structure", {
 test_that("run pmcmc with the particle filter and retain history", {
   proposal_kernel <- diag(2) * 1e-4
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
-  
+
   pars <- pmcmc_parameters$new(
     list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
                          prior = function(p) log(1e-10)),
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal = proposal_kernel)
-  
+
   dat <- example_sir()
   n_particles <- 100
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
-  
+
   control1 <- pmcmc_control(30, save_trajectories = TRUE, save_state = TRUE)
   control2 <- pmcmc_control(30, save_trajectories = FALSE, save_state = FALSE)
-  
+
   set.seed(1)
   results1 <- pmcmc(pars, p1, control = control1)
   set.seed(1)
   results2 <- pmcmc(pars, p2, control = control2)
-  
+
   expect_setequal(
     names(results1),
     c("chain", "iteration",
       "pars", "probabilities", "state", "trajectories", "restart", "predict"))
-  
+
   expect_null(results1$chain)
   expect_equal(results1$iteration, 0:30)
-  
+
   ## Including or not the history does not change the mcmc trajectory:
   expect_identical(names(results1), names(results2))
   expect_equal(results1$pars, results2$pars)
   expect_equal(results1$probabilities, results2$probabilities)
-  
+
   ## We did mix
   expect_true(all(acceptance_rate(results1$pars) > 0))
-  
+
   ## Parameters and probabilities have the expected shape
   expect_equal(dim(results1$pars), c(31, 2))
   expect_equal(colnames(results1$pars), c("beta", "gamma"))
-  
+
   expect_equal(dim(results1$probabilities), c(31, 3))
   expect_equal(colnames(results1$probabilities),
                c("log_prior", "log_likelihood", "log_posterior"))
-  
+
   ## History, if returned, has the correct shape
   expect_equal(dim(results1$state), c(5, 31)) # state, mcmc
-  
+
   ## Trajectories, if returned, have the same shape
   expect_s3_class(results1$trajectories, "mcstate_trajectories")
   expect_equal(dim(results1$trajectories$state), c(3, 31, 101))
@@ -144,7 +144,7 @@ test_that("run pmcmc with the particle filter and retain history", {
   expect_equal(results1$trajectories$predicted, rep(FALSE, 101))
   expect_equal(results1$trajectories$step, seq(0, 400, by = 4))
   expect_equal(results1$trajectories$rate, 4)
-  
+
   ## Additional information required to predict
   expect_setequal(
     names(results1$predict),
@@ -166,7 +166,7 @@ test_that("collecting state from model yields an RNG state", {
                             index = dat$index, seed = 1L)
   p3 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index, seed = 2L)
-  
+
   set.seed(1)
   results1 <- pmcmc(dat$pars, p1,
                     control = pmcmc_control(5, save_state = FALSE))
@@ -176,7 +176,7 @@ test_that("collecting state from model yields an RNG state", {
   set.seed(1)
   results3 <- pmcmc(dat$pars, p3,
                     control = pmcmc_control(5, save_state = TRUE))
-  
+
   expect_identical(
     r6_private(p1)$last_model$rng_state(),
     r6_private(p2)$last_model$rng_state())
@@ -200,20 +200,20 @@ test_that("running pmcmc with progress = TRUE prints messages", {
 
 test_that("run multiple chains", {
   dat <- example_uniform()
-  
+
   control1 <- pmcmc_control(100, save_state = FALSE, n_chains = 1)
   control2 <- pmcmc_control(100, save_state = FALSE, n_chains = 3)
-  
+
   set.seed(1)
   res1 <- pmcmc(dat$pars, dat$filter, control = control1)
   expect_s3_class(res1, "mcstate_pmcmc")
   expect_null(res1$chain)
-  
+
   set.seed(1)
   res3 <- pmcmc(dat$pars, dat$filter, control = control2)
   expect_s3_class(res3, "mcstate_pmcmc")
   expect_equal(res3$chain, rep(1:3, each = 101))
-  
+
   expect_equal(res1$pars, res3$pars[1:101, ])
 })
 
@@ -231,14 +231,14 @@ test_that("progress in multiple chains", {
 test_that("return names on pmcmc output", {
   proposal_kernel <- diag(2) * 1e-4
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
-  
+
   pars <- pmcmc_parameters$new(
     list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
                          prior = function(p) log(1e-10)),
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal = proposal_kernel)
-  
+
   dat <- example_sir()
   n_particles <- 10
   index2 <- function(info) list(run = 4L, state = c(a = 1, b = 2, c = 3))
@@ -246,14 +246,14 @@ test_that("return names on pmcmc output", {
                             index = dat$index)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = index2)
-  
+
   control <- pmcmc_control(5, save_state = TRUE, save_trajectories = TRUE)
-  
+
   set.seed(1)
   results1 <- pmcmc(pars, p1, control = control)
   set.seed(1)
   results2 <- pmcmc(pars, p2, control = control)
-  
+
   expect_null(rownames(results1$trajectories$state))
   expect_equal(rownames(results2$trajectories$state), c("a", "b", "c"))
 })
@@ -313,13 +313,13 @@ test_that("can validate a matrix initial conditions", {
   expect_error(
     pmcmc_check_initial(matrix(0.5, 2, 6), dat$pars, 5),
     "Expected a matrix with 5 columns for 'initial'")
-  
+
   expect_error(
     pmcmc_check_initial(matrix(0.5, 2, 5, dimnames = list(c("x", "y"), NULL)),
                         dat$pars, 5),
     "If 'initial' has rownames, they must match pars$names()",
     fixed = TRUE)
-  
+
   m <- matrix(runif(10), 2, 5)
   i <- cbind(c(2, 1, 2), c(2, 4, 5))
   m[i] <- -m[i]
@@ -342,30 +342,30 @@ test_that("can start a pmcmc from a matrix of starting points", {
 test_that("can trigger rerunning particle filter", {
   proposal_kernel <- diag(2) * 1e-4
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
-  
+
   pars <- pmcmc_parameters$new(
     list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
                          prior = function(p) log(1e-10)),
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal = proposal_kernel * 50)
-  
+
   dat <- example_sir()
   n_particles <- 100
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
-  
+
   control1 <- pmcmc_control(30, save_state = TRUE, save_trajectories = TRUE,
                             rerun_every = 2)
   control2 <- pmcmc_control(30, save_state = TRUE, save_trajectories = TRUE,
                             rerun_every = Inf)
-  
+
   set.seed(1)
   res1 <- pmcmc(pars, p1, control = control1)
   expect_lte(max(rle(res1$probabilities[, "log_likelihood"])$lengths), 2)
-  
+
   set.seed(1)
   res2 <- pmcmc(pars, p1, control = control2)
   expect_gt(max(rle(res2$probabilities[, "log_likelihood"])$lengths), 5)
@@ -377,12 +377,12 @@ test_that("rerunning the particle filter triggers the filter run method", {
   dat <- example_uniform()
   dat$filter$run <- mockery::mock(1, cycle = TRUE)
   dat$inputs <- function() NULL
-  
+
   ## with the dummy version we can't return history
   control <- pmcmc_control(10, rerun_every = 2, save_trajectories = FALSE,
                            save_state = FALSE)
   ans <- pmcmc(dat$pars, dat$filter, control = control)
-  
+
   mockery::expect_called(dat$filter$run, 16)
 })
 
@@ -390,26 +390,26 @@ test_that("rerunning the particle filter triggers the filter run method", {
 test_that("can partially run the pmcmc", {
   proposal_kernel <- diag(2) * 1e-4
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
-  
+
   pars <- pmcmc_parameters$new(
     list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
                          prior = function(p) log(1e-10)),
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal = proposal_kernel)
-  
+
   control <- pmcmc_control(30, save_state = TRUE, save_trajectories = TRUE)
-  
+
   dat <- example_sir()
   n_particles <- 42
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
-  
+
   set.seed(1)
   results1 <- pmcmc(pars, p1, control = control)
-  
+
   control$n_steps_each <- 10
   set.seed(1)
   initial <- pmcmc_check_initial(NULL, pars, 1)[, 1]
@@ -421,7 +421,7 @@ test_that("can partially run the pmcmc", {
   expect_equal(obj$run(), list(step = 30, finished = TRUE))
   expect_equal(obj$run(), list(step = 30, finished = TRUE))
   results2 <- obj$finish()
-  
+
   expect_equal(results2, results1)
 })
 
@@ -434,13 +434,13 @@ test_that("can change the number of threads mid-run", {
                             index = dat$index)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
-  
-  
+
+
   control <- pmcmc_control(30, save_trajectories = TRUE, save_state = TRUE)
-  
+
   set.seed(1)
   results1 <- pmcmc(dat$pars, p1, control = control)
-  
+
   control$n_steps_each <- 10
   set.seed(1)
   initial <- pmcmc_check_initial(NULL, dat$pars, 1)[, 1]
@@ -454,7 +454,7 @@ test_that("can change the number of threads mid-run", {
   expect_equal(r6_private(r6_private(obj)$filter)$n_threads, 1)
   expect_equal(obj$run(), list(step = 30, finished = TRUE))
   results2 <- obj$finish()
-  
+
   expect_equal(results2, results1)
 })
 
@@ -467,7 +467,7 @@ test_that("Can override thread count via control", {
   res <- pmcmc(dat$pars, p,
                control = pmcmc_control(5, n_threads_total = 2))
   expect_equal(res$predict$filter$n_threads, 2)
-  
+
   p$set_n_threads(4)
   res <- pmcmc(dat$pars, p,
                control = pmcmc_control(5, n_threads_total = NULL))
@@ -495,21 +495,21 @@ test_that("Can save intermediate state to restart", {
   res2 <- pmcmc(dat$pars, p2, control = control2)
   set.seed(1)
   res3 <- pmcmc(dat$pars, p3, control = control3)
-  
+
   ## Same actual run
   expect_identical(res1$trajectories, res2$trajectories)
   expect_identical(res1$trajectories, res3$trajectories)
-  
+
   expect_null(res1$restart)
-  
+
   expect_is(res2$restart, "list")
   expect_equal(res2$restart$time, 20)
   expect_equal(dim(res2$restart$state), c(5, 31, 1))
-  
+
   expect_is(res3$restart, "list")
   expect_equal(res3$restart$time, c(20, 30))
   expect_equal(dim(res3$restart$state), c(5, 31, 2))
-  
+
   expect_equal(res3$restart$state[, , 1], res2$restart$state[, , 1])
 })
 
@@ -520,14 +520,14 @@ test_that("can restart the mcmc using saved state", {
   ## these are harder questions.
   dat <- example_sir()
   n_particles <- 100
-  
+
   set.seed(1)
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   control1 <- pmcmc_control(50, save_trajectories = TRUE, save_state = TRUE,
                             progress = FALSE, save_restart = 40)
   res1 <- pmcmc(dat$pars, p1, control = control1)
-  
+
   ## Our new restart state, which includes a range of possible S
   ## values
   expect_equal(dim(res1$restart$state), c(5, 51, 1))
@@ -542,7 +542,7 @@ test_that("can restart the mcmc using saved state", {
   control2 <- pmcmc_control(50, save_trajectories = TRUE, save_state = TRUE,
                             progress = FALSE)
   res2 <- pmcmc(dat$pars, p2, control = control2)
-  
+
   expect_equal(res2$trajectories$step, (40:100) * 4)
   expect_equal(dim(res2$trajectories$state), c(3, 51, 61))
 })
@@ -551,22 +551,22 @@ test_that("can restart the mcmc using saved state", {
 test_that("Fix parameters in sir model", {
   proposal_kernel <- diag(2) * 1e-4
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
-  
+
   pars <- pmcmc_parameters$new(
     list(pmcmc_parameter("beta", 0.2, min = 0, max = 1,
                          prior = function(p) log(1e-10)),
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal = proposal_kernel)
-  
+
   pars2 <- pars$fix(c(gamma = 0.1))
-  
+
   dat <- example_sir()
   n_particles <- 40
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
   control <- pmcmc_control(10, save_trajectories = TRUE, save_state = TRUE)
-  
+
   results <- pmcmc(pars2, p, control = control)
   expect_equal(dim(results$pars), c(11, 1))
   expect_equal(results$predict$transform(pi), list(beta = pi, gamma = 0.1))
@@ -659,7 +659,7 @@ test_that("pmcmc_check_initial_nested - error matrix initial", {
 test_that("pmcmc nested Uniform on unit square - fixed only", {
   dat <- example_uniform_shared(varied = FALSE)
   control <- pmcmc_control(1000, save_state = FALSE, save_trajectories = FALSE)
-  
+
   set.seed(1)
   testthat::try_again(5, {
     res <- pmcmc(dat$pars, dat$filter, control = control)
@@ -675,7 +675,7 @@ test_that("pmcmc nested Uniform on unit square - fixed only", {
 test_that("pmcmc nested Uniform on unit square - varied only", {
   dat <- example_uniform_shared(fixed = FALSE)
   control <- pmcmc_control(1000, save_state = FALSE, save_trajectories = FALSE)
-  
+
   set.seed(1)
   testthat::try_again(5, {
     res <- pmcmc(dat$pars, dat$filter, control = control)
@@ -691,7 +691,7 @@ test_that("pmcmc nested Uniform on unit square - varied only", {
 test_that("pmcmc nested Uniform on unit square", {
   dat <- example_uniform_shared()
   control <- pmcmc_control(1000, save_state = FALSE, save_trajectories = FALSE)
-  
+
   set.seed(1)
   testthat::try_again(5, {
     res <- pmcmc(dat$pars, dat$filter, control = control)
@@ -709,7 +709,7 @@ test_that("pmcmc nested Uniform on unit square", {
 test_that("pmcmc nested multivariate gaussian", {
   dat <- example_mvnorm_shared()
   control <- pmcmc_control(500, save_state = FALSE, save_trajectories = FALSE)
-  
+
   set.seed(1)
   testthat::try_again(10, {
     res <- pmcmc(dat$pars, dat$filter, control = control)
@@ -744,7 +744,7 @@ test_that("pmcmc nested sir - 1 chain", {
                            n_chains = 1L)
   proposal_fixed <- matrix(0.00026)
   proposal_varied <- matrix(0.00057)
-  
+
   pars <- pmcmc_parameters_nested$new(
     list(pmcmc_varied_parameter("beta", letters[1:2], c(0.2, 0.3),
                                 min = 0, max = 1,
@@ -752,7 +752,7 @@ test_that("pmcmc nested sir - 1 chain", {
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal_fixed = proposal_fixed, proposal_varied = proposal_varied)
-  
+
   set.seed(1)
   res1 <- pmcmc(pars, p, control = control)
   set.seed(1)
@@ -769,7 +769,7 @@ test_that("pmcmc nested sir - 2 chains", {
                             dat$index, seed = 1L)
   proposal_fixed <- matrix(0.00026)
   proposal_varied <- matrix(0.00057)
-  
+
   pars <- pmcmc_parameters_nested$new(
     list(pmcmc_varied_parameter("beta", letters[1:2], c(0.2, 0.3),
                                 min = 0, max = 1,
@@ -777,25 +777,25 @@ test_that("pmcmc nested sir - 2 chains", {
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal_fixed = proposal_fixed, proposal_varied = proposal_varied)
-  
+
   control1 <- pmcmc_control(50, save_state = TRUE, n_chains = 1,
                             save_restart = c(10, 20, 30, 40),
                             save_trajectories = TRUE)
   control2 <- pmcmc_control(50, n_chains = 3, save_state = TRUE,
                             save_restart = c(10, 20, 30, 40),
                             save_trajectories = TRUE)
-  
+
   set.seed(1)
   res1 <- pmcmc(pars, p1, control = control1)
   expect_s3_class(res1, "mcstate_pmcmc")
   expect_null(res1$chain)
-  
+
   set.seed(1)
   res3 <- pmcmc(pars, p2, control = control2)
   expect_s3_class(res3, "mcstate_pmcmc")
   expect_equal(res3$chain, rep(1:3, each = 51))
   expect_equal(dim(res3$trajectories$state), c(3, 153, 2, 101))
-  
+
   expect_equal(res1$pars, res3$pars[, , 1:51])
   expect_equal(res1$state, res3$state[, , 1:51])
   expect_equal(res1$restart$state, res3$restart$state[, 1:51, , ])
@@ -812,10 +812,10 @@ test_that("return names on nested pmcmc output", {
   dat <- example_sir_shared()
   p1 <- particle_filter$new(dat$data, dat$model, 100, dat$compare,
                             dat$index, seed = 1L)
-  
+
   proposal_fixed <- matrix(0.00026)
   proposal_varied <- matrix(0.00057)
-  
+
   pars <- pmcmc_parameters_nested$new(
     list(pmcmc_varied_parameter("beta", letters[1:2], c(0.2, 0.3),
                                 min = 0, max = 1,
@@ -823,23 +823,23 @@ test_that("return names on nested pmcmc output", {
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal_fixed = proposal_fixed, proposal_varied = proposal_varied)
-  
+
   control1 <- pmcmc_control(50, save_state = FALSE, n_chains = 1)
-  
+
   n_particles <- 10
   index2 <- function(info) list(run = 4L, state = c(a = 1, b = 2, c = 3))
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = index2)
-  
+
   control <- pmcmc_control(5, save_state = TRUE, save_trajectories = TRUE)
-  
+
   set.seed(1)
   results1 <- pmcmc(pars, p1, control = control)
   set.seed(1)
   results2 <- pmcmc(pars, p2, control = control)
-  
+
   expect_null(rownames(results1$trajectories$state))
   expect_equal(rownames(results2$trajectories$state), c("a", "b", "c"))
 })
@@ -848,10 +848,10 @@ test_that("return names on nested pmcmc output", {
 
 test_that("run nested pmcmc with the particle filter and retain history", {
   dat <- example_sir_shared()
-  
+
   proposal_fixed <- matrix(0.00026)
   proposal_varied <- matrix(0.00057)
-  
+
   pars <- pmcmc_parameters_nested$new(
     list(pmcmc_varied_parameter("beta", letters[1:2], c(0.2, 0.3),
                                 min = 0, max = 1,
@@ -859,53 +859,53 @@ test_that("run nested pmcmc with the particle filter and retain history", {
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal_fixed = proposal_fixed, proposal_varied = proposal_varied)
-  
-  
+
+
   n_particles <- 100
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
-  
+
   control1 <- pmcmc_control(30, save_trajectories = TRUE, save_state = TRUE)
   control2 <- pmcmc_control(30, save_trajectories = FALSE, save_state = FALSE)
-  
+
   set.seed(1)
   results1 <- pmcmc(pars, p1, control = control1)
   set.seed(1)
   results2 <- pmcmc(pars, p2, control = control2)
-  
+
   expect_setequal(
     names(results1),
     c("chain", "iteration",
       "pars", "probabilities", "state", "trajectories", "restart", "predict"))
-  
+
   expect_null(results1$chain)
   expect_equal(results1$iteration, 0:30)
-  
+
   ## Including or not the history does not change the mcmc trajectory:
   expect_identical(names(results1), names(results2))
   expect_equal(results1$pars, results2$pars)
   expect_equal(results1$probabilities, results2$probabilities)
-  
+
   ## Parameters and probabilities have the expected shape
   expect_equal(dim(results1$pars), c(2, 2, 31))
   expect_equal(rownames(results1$pars), c("beta", "gamma"))
   expect_equal(colnames(results1$pars), c("a", "b"))
-  
+
   expect_equal(dim(results1$probabilities), c(3, 2, 31))
   expect_equal(rownames(results1$probabilities),
                c("log_prior", "log_likelihood", "log_posterior"))
-  
+
   ## History, if returned, has the correct shape
   expect_equal(dim(results1$state), c(5, 2, 31)) # state, mcmc
-  
+
   ## Trajectories, if returned, have the same shape
   expect_s3_class(results1$trajectories, "mcstate_trajectories")
   expect_equal(dim(results1$trajectories$state), c(3, 31, 2, 101))
   expect_equal(results1$trajectories$step, seq(0, 400, by = 4))
   expect_equal(results1$trajectories$rate, 4)
-  
+
   ## Additional information required to predict
   expect_setequal(
     names(results1$predict),
@@ -919,7 +919,7 @@ test_that("nested_step_ratio works", {
                            dat$index)
   proposal_fixed <- matrix(0.00026)
   proposal_varied <- matrix(0.00057)
-  
+
   pars <- pmcmc_parameters_nested$new(
     list(pmcmc_varied_parameter("beta", letters[1:2], c(0.2, 0.3),
                                 min = 0, max = 1,
@@ -927,12 +927,12 @@ test_that("nested_step_ratio works", {
          pmcmc_parameter("gamma", 0.1, min = 0, max = 1,
                          prior = function(p) log(1e-10))),
     proposal_fixed = proposal_fixed, proposal_varied = proposal_varied)
-  
+
   control <- pmcmc_control(30, nested_step_ratio = 30)
   res1 <- pmcmc(pars, p, control = control)
   expect_equal(as.numeric(res1$pars[1, , ]), rep(c(0.2, 0.3), 31))
   expect_false(identical(as.numeric(res1$pars[2, , ]), rep(0.1, 62)))
-  
+
   control <- pmcmc_control(30, nested_step_ratio = 1 / 30)
   res2 <- pmcmc(pars, p, control = control)
   expect_equal(as.numeric(res2$pars[2, , ]), rep(0.1, 62))


### PR DESCRIPTION
Adds `nested_step_ratio` parameter to `pmcmc_control` for controlling ratio of fixed:varied steps