### PR TITLE
Use compiled particle filter if given a compiled compare function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.5.10
+Version: 0.5.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
     callr (>= 3.5.1),
-    dust (>= 0.7.9),
+    dust (>= 0.8.5),
     processx,
     progress (>= 1.2.0)
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.5.11
+
+* The particle filter can now run entirely in compiled code if supported by the model. This may give a small performance gain, particularly on very simple models, or of the model has an expensive compare function (#118)
+
 # mcstate 0.5.9
 
 * Add `nested_step_ratio` parameter to `pmcmc_control` for controlling the ratio of fixed:varied steps for nested pMCMC

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -513,26 +513,32 @@ check_save_restart <- function(save_restart, data) {
 
 history_single <- function(history_value, history_order, history_index,
                            index_particle) {
-
   ny <- nrow(history_value)
 
-  if (is.null(index_particle)) {
-    index_particle <- seq_len(ncol(history_value))
+  if (is.null(history_order)) {
+    if (is.null(index_particle)) {
+      ret <- history_value
+    } else {
+      ret <- history_value[, index_particle, , drop = FALSE]
+    }
+  } else {
+    if (is.null(index_particle)) {
+      index_particle <- seq_len(ncol(history_value))
+    }
+
+    np <- length(index_particle)
+    nt <- ncol(history_order)
+
+    idx <- matrix(NA_integer_, np, nt)
+    for (i in rev(seq_len(ncol(idx)))) {
+      index_particle <- idx[, i] <- history_order[index_particle, i]
+    }
+
+    cidx <- cbind(seq_len(ny),
+                  rep(idx, each = ny),
+                  rep(seq_len(nt), each = ny * np))
+    ret <- array(history_value[cidx], c(ny, np, nt))
   }
-
-  np <- length(index_particle)
-
-  nt <- ncol(history_order)
-
-  idx <- matrix(NA_integer_, np, nt)
-  for (i in rev(seq_len(ncol(idx)))) {
-    index_particle <- idx[, i] <- history_order[index_particle, i]
-  }
-
-  cidx <- cbind(seq_len(ny),
-                rep(idx, each = ny),
-                rep(seq_len(nt), each = ny * np))
-  ret <- array(history_value[cidx], c(ny, np, nt))
   rownames(ret) <- names(history_index)
   ret
 }
@@ -543,6 +549,9 @@ history_nested <- function(history_value, history_order, history_index,
   npop <- ncol(history_order)
   nt <- nlayer(history_order)
 
+  if (is.null(history_index)) {
+    browser()
+  }
 
   if (is.null(index_particle)) {
     index_particle <- matrix(seq_len(ncol(history_value)),

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -543,12 +543,18 @@ history_single <- function(history_value, history_order, history_index,
   ret
 }
 
+## This function handles the nested/non-nested case but also the
+## compiled/non-compiled case. In the compiled case we already have
+## our history nicely ordered (that is the states convered into a tree
+## based on the history of particle sampling) and history_order is
+## NULL.
 history_nested <- function(history_value, history_order, history_index,
                            index_particle) {
   ny <- nrow(history_value)
+  npop <- nlayer(history_value)
 
   if (is.null(history_order)) {
-    npop <- nlayer(history_value)
+    ## Compiled particle filter; no ordering needed (or available)
     if (is.null(index_particle)) {
       ret <- history_value
     } else if (!is.matrix(index_particle)) {
@@ -565,7 +571,7 @@ history_nested <- function(history_value, history_order, history_index,
       }
     }
   } else {
-    npop <- ncol(history_order)
+    ## mcstate particle filter; need to sort the history
     nt <- nlayer(history_order)
 
     if (is.null(index_particle)) {

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -549,41 +549,48 @@ history_nested <- function(history_value, history_order, history_index,
   npop <- ncol(history_order)
   nt <- nlayer(history_order)
 
-  if (is.null(history_index)) {
-    browser()
-  }
-
-  if (is.null(index_particle)) {
-    index_particle <- matrix(seq_len(ncol(history_value)),
-                             ncol(history_value), npop)
-  } else {
-    if (is.matrix(index_particle)) {
-      if (!ncol(index_particle) == npop) {
-        stop(sprintf("'index_particle' should have %d columns", npop))
-      }
+  if (is.null(history_order)) {
+    npop <- nlayer(history_value)
+    if (is.null(index_particle)) {
+      ret <- history_value
+    } else if (!is.matrix(index_particle)) {
+      ret <- history_value[, index_particle, , , drop = FALSE]
     } else {
-      index_particle <- matrix(index_particle,
-                               nrow = length(index_particle),
-                               ncol = npop)
+      stop("WRITEME")
     }
-  }
-
-  np <- nrow(index_particle)
-
-  idx <- array(NA_integer_, c(np, npop, nt))
-  for (i in rev(seq_len(nlayer(idx)))) {
-    for (j in seq_len(npop)) {
-      idx[, j, i] <- history_order[, j, i][index_particle[, j]]
+  } else {
+    if (is.null(index_particle)) {
+      index_particle <- matrix(seq_len(ncol(history_value)),
+                               ncol(history_value), npop)
+    } else {
+      if (is.matrix(index_particle)) {
+        if (!ncol(index_particle) == npop) {
+          stop(sprintf("'index_particle' should have %d columns", npop))
+        }
+      } else {
+        index_particle <- matrix(index_particle,
+                                 nrow = length(index_particle),
+                                 ncol = npop)
+      }
     }
-    index_particle <- matrix(idx[, , i], nrow = np, ncol = npop)
-  }
 
-  ret <- array(NA, c(ny, np, npop, nt))
-  for (i in seq_len(npop)) {
-    cidx <- cbind(seq_len(ny),
-                  rep(idx[, i, ], each = ny),
-                  rep(seq_len(nt), each = ny * np))
-    ret[, , i, ] <- history_value[, , i, ][cidx]
+    np <- nrow(index_particle)
+
+    idx <- array(NA_integer_, c(np, npop, nt))
+    for (i in rev(seq_len(nlayer(idx)))) {
+      for (j in seq_len(npop)) {
+        idx[, j, i] <- history_order[, j, i][index_particle[, j]]
+      }
+      index_particle <- matrix(idx[, , i], nrow = np, ncol = npop)
+    }
+
+    ret <- array(NA, c(ny, np, npop, nt))
+    for (i in seq_len(npop)) {
+      cidx <- cbind(seq_len(ny),
+                    rep(idx[, i, ], each = ny),
+                    rep(seq_len(nt), each = ny * np))
+      ret[, , i, ] <- history_value[, , i, ][cidx]
+    }
   }
   rownames(ret) <- names(history_index)
   ret

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -546,8 +546,6 @@ history_single <- function(history_value, history_order, history_index,
 history_nested <- function(history_value, history_order, history_index,
                            index_particle) {
   ny <- nrow(history_value)
-  npop <- ncol(history_order)
-  nt <- nlayer(history_order)
 
   if (is.null(history_order)) {
     npop <- nlayer(history_value)
@@ -556,9 +554,20 @@ history_nested <- function(history_value, history_order, history_index,
     } else if (!is.matrix(index_particle)) {
       ret <- history_value[, index_particle, , , drop = FALSE]
     } else {
-      stop("WRITEME")
+      if (!ncol(index_particle) == npop) {
+        stop(sprintf("'index_particle' should have %d columns", npop))
+      }
+      d <- dim(history_value)
+      d[[2L]] <- nrow(index_particle)
+      ret <- array(NA_real_, d)
+      for (i in seq_len(npop)) {
+        ret[, , i, ] <- history_value[, index_particle[, i], i, ]
+      }
     }
   } else {
+    npop <- ncol(history_order)
+    nt <- nlayer(history_order)
+
     if (is.null(index_particle)) {
       index_particle <- matrix(seq_len(ncol(history_value)),
                                ncol(history_value), npop)

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -225,11 +225,7 @@ particle_filter_state <- R6::R6Class(
           history_value[, , t + 1L] <- model$state(save_history_index)
         }
 
-        if (is.null(compare)) {
-          log_weights <- model$compare_data()
-        } else {
-          log_weights <- compare(state, data_split[[t]], pars)
-        }
+        log_weights <- compare(state, data_split[[t]], pars)
 
         if (is.null(log_weights)) {
           if (save_history) {

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -138,7 +138,11 @@ particle_filter_state <- R6::R6Class(
     ##' a convenience function around `$step()` which provides the correct
     ##' value of `step_index`
     run = function() {
-      self$step(private$n_steps)
+      if (is.null(private$compare)) {
+        particle_filter_compiled(self, private)
+      } else {
+        self$step(private$n_steps)
+      }
     },
 
     ##' @description Take a step with the particle filter. This moves
@@ -174,6 +178,20 @@ particle_filter_state <- R6::R6Class(
       model <- self$model
       compare <- private$compare
 
+      ## This needs a little work in dust:
+      ## https://github.com/mrc-ide/dust/issues/177
+      if (is.null(compare)) {
+        stop("Can't use low-level step with compiled particle filter (yet)")
+      }
+
+      steps <- private$steps
+      data_split <- private$data_split
+      pars <- private$pars
+
+      restart_state <- self$restart_state
+      save_restart_step <- private$save_restart_step
+      save_restart <- !is.null(restart_state)
+
       history <- self$history
       save_history <- !is.null(history)
       save_history_index <- self$history$index
@@ -182,40 +200,6 @@ particle_filter_state <- R6::R6Class(
 
       log_likelihood <- self$log_likelihood
       n_particles <- private$n_particles
-
-      ## I think that this can be factored into a little utility
-      ## because it will be very shared with the multiple parameter
-      ## case too.
-      if (is.null(compare)) {
-        ## This needs a little work in dust:
-        ## https://github.com/mrc-ide/dust/issues/177
-        if (curr != 0L || step_index != n_steps || partial) {
-          stop("Partial particle filter running not supported")
-        }
-        if (save_history) {
-          model$set_index(save_history_index)
-          on.exit(model$set_index(integer(0)))
-        }
-        res <- model$filter(save_history, private$save_restart_step)
-
-        self$log_likelihood_step <- NA_real_
-        self$log_likelihood <- res$log_likelihood
-        private$current_step_index <- step_index
-        if (save_history) {
-          self$history <- list(value = res$trajectories,
-                               index = save_history_index)
-        }
-        self$restart_state <- res$snapshots
-        return(res$log_likelihood)
-      }
-
-      steps <- private$steps
-      data_split <- private$data_split
-      pars <- private$pars
-
-      save_restart_step <- private$save_restart_step
-      restart_state <- self$restart_state
-      save_restart <- !is.null(restart_state)
 
       for (t in seq(curr + 1L, step_index)) {
         step_end <- steps[t, 2L]
@@ -303,3 +287,30 @@ particle_filter_state <- R6::R6Class(
       ret
     }
   ))
+
+
+## This is used by both the nested and non-nested particle filter, and
+## outsources all the work to dust.
+particle_filter_compiled <- function(self, private) {
+  history <- self$history
+  save_history <- !is.null(history)
+  save_history_index <- self$history$index
+
+  model <- self$model
+  if (save_history) {
+    model$set_index(save_history_index)
+    on.exit(model$set_index(integer(0)))
+  }
+
+  res <- model$filter(save_history, private$save_restart_step)
+
+  self$log_likelihood_step <- NA_real_
+  self$log_likelihood <- res$log_likelihood
+  private$current_step_index <- private$n_steps
+  if (save_history) {
+    self$history <- list(value = res$trajectories,
+                         index = save_history_index)
+  }
+  self$restart_state <- res$snapshots
+  res$log_likelihood
+}

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -172,11 +172,7 @@ particle_filter_state <- R6::R6Class(
       }
 
       model <- self$model
-
       compare <- private$compare
-      steps <- private$steps
-      data_split <- private$data_split
-      pars <- private$pars
 
       restart_state <- self$restart_state
       save_restart_step <- private$save_restart_step
@@ -190,6 +186,29 @@ particle_filter_state <- R6::R6Class(
 
       log_likelihood <- self$log_likelihood
       n_particles <- private$n_particles
+
+      if (is.null(compare)) {
+        ## Each of these is a feature that needs implementing, mostly in dust
+        if (!save_restart && curr == 0L && step_index == n_steps && !partial) {
+          if (save_history) {
+            model$set_index(save_history_index)
+            on.exit(model$set_index(integer(0)))
+          }
+          ret <- model$filter(save_history)
+          self$log_likelihood_step <- NA_real_
+          self$log_likelihood <- ret$log_likelihood
+          private$current_step_index <- step_index
+          if (save_history) {
+            self$history <- list(value = ret$history,
+                                 index = save_history_index)
+          }
+          return(ret$log_likelihood)
+        }
+      }
+
+      steps <- private$steps
+      data_split <- private$data_split
+      pars <- private$pars
 
       for (t in seq(curr + 1L, step_index)) {
         step_end <- steps[t, 2L]

--- a/R/particle_filter_state_nested.R
+++ b/R/particle_filter_state_nested.R
@@ -180,12 +180,7 @@ particle_filter_state_nested <- R6::R6Class(
       }
 
       model <- self$model
-
       compare <- private$compare
-
-      restart_state <- self$restart_state
-      save_restart_step <- private$save_restart_step
-      save_restart <- !is.null(restart_state)
 
       history <- self$history
       save_history <- !is.null(history)
@@ -221,6 +216,10 @@ particle_filter_state_nested <- R6::R6Class(
       steps <- private$steps
       data_split <- private$data_split
       pars <- private$pars
+
+      restart_state <- self$restart_state
+      save_restart_step <- private$save_restart_step
+      save_restart <- !is.null(restart_state)
 
       for (t in seq(curr + 1L, step_index)) {
         step_end <- steps[t, 2L]

--- a/R/particle_filter_state_nested.R
+++ b/R/particle_filter_state_nested.R
@@ -200,22 +200,21 @@ particle_filter_state_nested <- R6::R6Class(
         ## TODO: this section is a copy of a similar section in the
         ## unnested filter. It's hard to factor out because we need
         ## many inputs and we write to both self and private...
-        ##
-        ## Each of these is a feature that needs implementing, mostly in dust
-        if (!save_restart && curr == 0L && step_index == n_steps) {
+        if (curr == 0L && step_index == n_steps) {
           if (save_history) {
             model$set_index(save_history_index)
             on.exit(model$set_index(integer(0)))
           }
-          ret <- model$filter(save_history)
+          res <- model$filter(save_history, private$save_restart_step)
           self$log_likelihood_step <- NA_real_
-          self$log_likelihood <- ret$log_likelihood
+          self$log_likelihood <- res$log_likelihood
           private$current_step_index <- step_index
           if (save_history) {
-            self$history <- list(value = ret$history,
+            self$history <- list(value = res$trajectories,
                                  index = save_history_index)
           }
-          return(ret$log_likelihood)
+          self$restart_state <- res$snapshots
+          return(res$log_likelihood)
         }
       }
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -626,8 +626,8 @@ test_that("use compiled compare function", {
   ## easy to see that these are the same (this just takes the best
   ## part of a minute and replicates the unit tests available
   ## elsewhere)
-  system.time(y1 <- replicate(50, p1$run()))
-  system.time(y2 <- replicate(50, p2$run()))
+  y1 <- replicate(50, p1$run())
+  y2 <- replicate(50, p2$run())
   expect_equal(mean(y1), mean(y2), tolerance = 0.01)
 })
 
@@ -650,6 +650,28 @@ test_that("Can get history with compiled particle filter", {
   expect_true(all(diff(t(p2$history()[3, , ])) >= 0))
   expect_equal(dim(p1$history(1L)), dim(p2$history(1L)))
   expect_equal(dim(p1$history(1:5)), dim(p2$history(1:5)))
+})
+
+
+test_that("Can save restart with compiled particle filter", {
+  dat <- example_sir()
+  n_particles <- 100
+  set.seed(1)
+
+  model <- dust::dust_example("sir")
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index)
+  p2 <- particle_filter$new(dat$data, model, n_particles, NULL,
+                            index = dat$index)
+
+  at <- c(10, 20, 40, 80)
+  p1$run(save_restart = at)
+  p2$run(save_restart = at)
+
+  expect_equal(dim(p1$restart_state()), dim(p2$restart_state()))
+  expect_true(all(diff(t(p2$restart_state()[3, , ])) >= 0))
+  expect_equal(dim(p1$restart_state(1L)), dim(p2$restart_state(1L)))
+  expect_equal(dim(p1$restart_state(1:5)), dim(p2$restart_state(1:5)))
 })
 
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -768,6 +768,25 @@ test_that("Can't run past the end of the data", {
 })
 
 
+test_that("Can't partially run a compiled filter", {
+  dat <- example_sir()
+  p <- particle_filter$new(dat$data, dat$model, 10, NULL,
+                           index = dat$index, seed = 1L)
+  expect_error(p$run_begin()$step(5),
+               "Partial particle filter running not supported")
+})
+
+test_that("Can't partially run a compiled filter (nested)", {
+  dat <- example_sir_shared()
+  pars <- list(list(beta = 0.2, gamma = 0.1),
+               list(beta = 0.3, gamma = 0.1))
+  p <- particle_filter$new(dat$data, dat$model, 10, NULL,
+                           index = dat$index)
+  expect_error(p$run_begin(pars)$step(5),
+               "Partial particle filter running not supported")
+})
+
+
 test_that("Can fork a particle_filter_state object", {
   dat <- example_sir()
   n_particles <- 42
@@ -1004,7 +1023,7 @@ test_that("Can fork a particle_filter_state_nested object", {
   n_particles <- 42
 
   pars <- list(list(beta = 0.2, gamma = 0.1),
-                               list(beta = 0.3, gamma = 0.1))
+               list(beta = 0.3, gamma = 0.1))
 
   set.seed(1)
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -643,11 +643,6 @@ test_that("Can get history with compiled particle filter", {
   p2 <- particle_filter$new(dat$data, model, n_particles, NULL,
                             index = dat$index)
 
-  ## Proving these are the same is tricky to do in a sensible amount
-  ## of time but if we run 1000 replicates with 400 particles it's
-  ## easy to see that these are the same (this just takes the best
-  ## part of a minute and replicates the unit tests available
-  ## elsewhere)
   p1$run(save_history = TRUE)
   p2$run(save_history = TRUE)
 
@@ -890,7 +885,7 @@ test_that("use compiled compare function - nested", {
   set.seed(1)
 
   pars <- list(list(beta = 0.2, gamma = 0.1),
-                               list(beta = 0.3, gamma = 0.1))
+               list(beta = 0.3, gamma = 0.1))
 
   model <- dust::dust_example("sir")
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
@@ -902,6 +897,34 @@ test_that("use compiled compare function - nested", {
   y2 <- replicate(50, p2$run(pars))
   expect_equal(mean(y1), mean(y2), tolerance = 0.01)
 })
+
+
+test_that("can get history with compiled particle filter on nested model", {
+  dat <- example_sir_shared()
+  n_particles <- 42
+  set.seed(1)
+
+  pars <- list(list(beta = 0.2, gamma = 0.1),
+                               list(beta = 0.3, gamma = 0.1))
+
+  model <- dust::dust_example("sir")
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index)
+  p2 <- particle_filter$new(dat$data, model, n_particles, NULL,
+                            index = dat$index)
+
+  ## TODO: p1$run(save_history = TRUE) does not work but does in the
+  ## unnested case.
+  p1$run(pars, save_history = TRUE)
+  p2$run(pars, save_history = TRUE)
+
+  expect_equal(dim(p1$history()), dim(p2$history()))
+  expect_true(all(diff(t(p2$history()[3, , 1, ])) >= 0))
+  expect_true(all(diff(t(p2$history()[3, , 2, ])) >= 0))
+  expect_equal(dim(p1$history(1L)), dim(p2$history(1L)))
+  expect_equal(dim(p1$history(1:5)), dim(p2$history(1:5)))
+})
+
 
 test_that("particle filter state nested - errors", {
   dat <- example_sir_shared()

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -887,7 +887,7 @@ test_that("Can extract state from the model - nested", {
   n_particles <- 42
   set.seed(1)
   pars <- list(list(beta = 0.2, gamma = 0.1),
-                               list(beta = 0.3, gamma = 0.1))
+               list(beta = 0.3, gamma = 0.1))
   seed <- 100
   index <- function(info) {
     list(run = 5L, state = 1:3)
@@ -962,6 +962,15 @@ test_that("can get history with compiled particle filter on nested model", {
   expect_true(all(diff(t(p2$history()[3, , 2, ])) >= 0))
   expect_equal(dim(p1$history(1L)), dim(p2$history(1L)))
   expect_equal(dim(p1$history(1:5)), dim(p2$history(1:5)))
+
+  idx <- cbind(1:4, 2:5)
+  h2 <- p2$history(idx)
+  expect_equal(dim(h2), dim(p1$history(idx)))
+  expect_equal(h2[, , 1, ], p2$history()[, 1:4, 1, ])
+  expect_equal(h2[, , 2, ], p2$history()[, 2:5, 2, ])
+
+  expect_error(p2$history(idx[, c(1, 1, 2)]),
+               "'index_particle' should have 2 columns")
 })
 
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -935,8 +935,6 @@ test_that("can get history with compiled particle filter on nested model", {
   p2 <- particle_filter$new(dat$data, model, n_particles, NULL,
                             index = dat$index)
 
-  ## TODO: p1$run(save_history = TRUE) does not work but does in the
-  ## unnested case.
   p1$run(pars, save_history = TRUE)
   p2$run(pars, save_history = TRUE)
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -773,8 +773,10 @@ test_that("Can't partially run a compiled filter", {
   p <- particle_filter$new(dat$data, dat$model, 10, NULL,
                            index = dat$index, seed = 1L)
   expect_error(p$run_begin()$step(5),
-               "Partial particle filter running not supported")
+               "Can't use low-level step with compiled particle filter (yet)",
+               fixed = TRUE)
 })
+
 
 test_that("Can't partially run a compiled filter (nested)", {
   dat <- example_sir_shared()
@@ -783,7 +785,8 @@ test_that("Can't partially run a compiled filter (nested)", {
   p <- particle_filter$new(dat$data, dat$model, 10, NULL,
                            index = dat$index)
   expect_error(p$run_begin(pars)$step(5),
-               "Partial particle filter running not supported")
+               "Can't use low-level step with compiled particle filter (yet)",
+               fixed = TRUE)
 })
 
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -626,9 +626,35 @@ test_that("use compiled compare function", {
   ## easy to see that these are the same (this just takes the best
   ## part of a minute and replicates the unit tests available
   ## elsewhere)
-  y1 <- replicate(50, p1$run())
-  y2 <- replicate(50, p2$run())
+  system.time(y1 <- replicate(50, p1$run()))
+  system.time(y2 <- replicate(50, p2$run()))
   expect_equal(mean(y1), mean(y2), tolerance = 0.01)
+})
+
+
+test_that("Can get history with compiled particle filter", {
+  dat <- example_sir()
+  n_particles <- 100
+  set.seed(1)
+
+  model <- dust::dust_example("sir")
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index)
+  p2 <- particle_filter$new(dat$data, model, n_particles, NULL,
+                            index = dat$index)
+
+  ## Proving these are the same is tricky to do in a sensible amount
+  ## of time but if we run 1000 replicates with 400 particles it's
+  ## easy to see that these are the same (this just takes the best
+  ## part of a minute and replicates the unit tests available
+  ## elsewhere)
+  p1$run(save_history = TRUE)
+  p2$run(save_history = TRUE)
+
+  expect_equal(dim(p1$history()), dim(p2$history()))
+  expect_true(all(diff(t(p2$history()[3, , ])) >= 0))
+  expect_equal(dim(p1$history(1L)), dim(p2$history(1L)))
+  expect_equal(dim(p1$history(1:5)), dim(p2$history(1:5)))
 })
 
 


### PR DESCRIPTION
This PR starts us towards using dust's particle filter engine rather than the pure R one. This should be slightly more efficient in copying and also runs the compare function in parallel. It will be interesting to see what the gain is on sircovid but I think there was scope for about a 10% improvement there (so ok, but not great). This is also needed to move us towards longer term work where the particle filter will be available on the GPU.

There's some tension here with supporting the partial run (itself for SMC^2). To do this in dust requires that we implement https://github.com/mrc-ide/dust/issues/177 - once that's done things might actually get easier

Fixes #118 