### PR TITLE
Optionally save chains to disk

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.5.13
+Version: 0.5.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -116,17 +116,27 @@ pmcmc_chains_prepare <- function(pars, filter, initial = NULL, control = NULL) {
 ##'
 ##' @param inputs A `pmcmc_inputs` object created by `pmcmc_chains_prepare`
 ##'
+##' @param path Optionally a path to save output in. This might be
+##'   useful if splitting work across multiple processes.
+##'
 ##' @export
 ##' @rdname pmcmc_chains_prepare
-pmcmc_chains_run <- function(chain_id, inputs) {
+pmcmc_chains_run <- function(chain_id, inputs, path = NULL) {
   assert_is(inputs, "pmcmc_inputs")
   assert_scalar_positive_integer(chain_id)
   if (chain_id < 1 || chain_id > inputs$control$n_chains) {
     stop(sprintf("'chain_id' must be an integer in 1..%d",
                  inputs$control$n_chains))
   }
-  pmcmc_run_chain(chain_id, inputs$pars, inputs$initial, inputs$filter,
-                  inputs$control, inputs$seed)
+  samples <- pmcmc_run_chain(chain_id, inputs$pars, inputs$initial,
+                             inputs$filter, inputs$control, inputs$seed)
+  if (is.null(path)) {
+    samples
+  } else {
+    dir.create(dirname(path), FALSE, TRUE)
+    saveRDS(samples, path)
+    path
+  }
 }
 
 

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -116,8 +116,9 @@ pmcmc_chains_prepare <- function(pars, filter, initial = NULL, control = NULL) {
 ##'
 ##' @param inputs A `pmcmc_inputs` object created by `pmcmc_chains_prepare`
 ##'
-##' @param path Optionally a path to save output in. This might be
-##'   useful if splitting work across multiple processes.
+##' @param path Optionally a directory to save output in. This might
+##'   be useful if splitting work across multiple processes. Samples
+##'   will be saved at `<path>/samples_<chain_id>.rds`
 ##'
 ##' @export
 ##' @rdname pmcmc_chains_prepare
@@ -133,9 +134,11 @@ pmcmc_chains_run <- function(chain_id, inputs, path = NULL) {
   if (is.null(path)) {
     samples
   } else {
-    dir.create(dirname(path), FALSE, TRUE)
-    saveRDS(samples, path)
-    path
+    fmt <- "samples_%d.rds"
+    dir.create(path, FALSE, TRUE)
+    dest <- file.path(path, sprintf(fmt, chain_id))
+    saveRDS(samples, dest)
+    dest
   }
 }
 

--- a/man/pmcmc_chains_prepare.Rd
+++ b/man/pmcmc_chains_prepare.Rd
@@ -7,7 +7,7 @@
 \usage{
 pmcmc_chains_prepare(pars, filter, initial = NULL, control = NULL)
 
-pmcmc_chains_run(chain_id, inputs)
+pmcmc_chains_run(chain_id, inputs, path = NULL)
 }
 \arguments{
 \item{pars}{A \code{\link{pmcmc_parameters}} object containing
@@ -32,6 +32,9 @@ and any of the parameters above aside from \code{pars} and \code{filter}.}
 \item{chain_id}{The chain index to run (1, 2, ..., \code{control$n_chains})}
 
 \item{inputs}{A \code{pmcmc_inputs} object created by \code{pmcmc_chains_prepare}}
+
+\item{path}{Optionally a path to save output in. This might be
+useful if splitting work across multiple processes.}
 }
 \description{
 Run a pMCMC, with sensible random number behaviour, but schedule

--- a/man/pmcmc_chains_prepare.Rd
+++ b/man/pmcmc_chains_prepare.Rd
@@ -33,8 +33,9 @@ and any of the parameters above aside from \code{pars} and \code{filter}.}
 
 \item{inputs}{A \code{pmcmc_inputs} object created by \code{pmcmc_chains_prepare}}
 
-\item{path}{Optionally a path to save output in. This might be
-useful if splitting work across multiple processes.}
+\item{path}{Optionally a directory to save output in. This might
+be useful if splitting work across multiple processes. Samples
+will be saved at \verb{<path>/samples_<chain_id>.rds}}
 }
 \description{
 Run a pMCMC, with sensible random number behaviour, but schedule

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -1061,7 +1061,7 @@ test_that("Split chain and write to file", {
   expect_true(file.exists(path))
   expect_true(file.info(path)$isdir)
   expect_true(all(file.exists(samples_path)))
-  expect_equal(dirname(samples_path), rep(path, 4))
+  expect_setequal(dir(path), basename(samples_path))
   expect_equal(basename(samples_path),
                sprintf("samples_%d.rds", 1:4))
   samples <- lapply(samples_path, readRDS)


### PR DESCRIPTION
Extends the previous prepare/run to allow saving to a series of files, which can be reconstituted in another session later. This should avoid trying to serialise very long vectors into Redis in our rtm workflow