### PR TITLE
Allow running particle filter on gpu

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -76,7 +76,7 @@ jobs:
         shell: Rscript {0}
 
       - name: debug
-        if: runner.os == "Linux"
+        if: runner.os == 'Linux'
         uses: mxschmitt/action-tmate@v3
 
       - name: Check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,6 +75,10 @@ jobs:
           install.packages(".", repos = NULL, type = "source")
         shell: Rscript {0}
 
+      - name: debug
+        if: runner.os == "Linux"
+        uses: mxschmitt/action-tmate@v3
+
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,10 +75,6 @@ jobs:
           install.packages(".", repos = NULL, type = "source")
         shell: Rscript {0}
 
-      - name: debug
-        if: runner.os == 'Linux'
-        uses: mxschmitt/action-tmate@v3
-
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ URL: https://github.com/mrc-ide/mcstate
 BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
-    callr (>= 3.5.1),
+    callr (>= 3.7.0),
     dust (>= 0.9.2),
     processx,
     progress (>= 1.2.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE := $(shell grep '^Package:' DESCRIPTION | sed -E 's/^Package:[[:space:]]+//')
-RSCRIPT = Rscript --no-init-file
+RSCRIPT = Rscript
 
 all: install
 

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -415,6 +415,7 @@ particle_filter <- R6::R6Class(
            index = private$index,
            initial = private$initial,
            compare = private$compare,
+           device_id = private$device_id,
            n_threads = private$n_threads,
            seed = seed)
     },
@@ -456,6 +457,7 @@ particle_filter_from_inputs <- function(inputs, seed = NULL) {
                       model = inputs$model,
                       n_particles = inputs$n_particles,
                       compare = inputs$compare,
+                      device_id = inputs$device_id,
                       index = inputs$index,
                       initial = inputs$initial,
                       n_threads = inputs$n_threads,

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -272,13 +272,14 @@ particle_filter_state <- R6::R6Class(
     ##' @param pars New model parameters
     fork = function(pars) {
       stopifnot(!private$device) # this won't work
+      device_id <- NULL
       seed <- self$model$rng_state()
       save_history <- !is.null(self$history)
       ret <- particle_filter_state$new(
         pars, private$generator, NULL, private$data, private$data_split,
         private$steps, private$n_particles, private$n_threads,
-        private$initial, private$index, private$compare, seed,
-        save_history, private$save_restart)
+        private$initial, private$index, private$compare, device_id,
+        seed, save_history, private$save_restart)
 
       ## Run it up to the same point
       ret$step(private$current_step_index)

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -26,6 +26,7 @@ particle_filter_state <- R6::R6Class(
     initial = NULL,
     index = NULL,
     compare = NULL,
+    device = NULL,
     save_restart_step = NULL,
     save_restart = NULL,
     current_step_index = 0L
@@ -60,13 +61,13 @@ particle_filter_state <- R6::R6Class(
     ##' documented.
     initialize = function(pars, generator, model, data, data_split, steps,
                           n_particles, n_threads, initial, index, compare,
-                          seed, save_history, save_restart) {
+                          device_id, seed, save_history, save_restart) {
       ## NOTE: this will generate a warning when updating docs but
       ## that's ok; see https://github.com/r-lib/roxygen2/issues/1067
       if (is.null(model)) {
         model <- generator$new(pars = pars, step = steps[[1L]],
                                n_particles = n_particles, n_threads = n_threads,
-                               seed = seed)
+                               seed = seed, device_id = device_id)
         if (is.null(compare)) {
           model$set_index(integer(0))
           model$set_data(data_split)
@@ -126,6 +127,7 @@ particle_filter_state <- R6::R6Class(
       private$initial <- initial
       private$index <- index
       private$compare <- compare
+      private$device <- !is.null(device_id)
       private$save_restart_step <- save_restart_step
       private$save_restart <- save_restart
 
@@ -139,7 +141,7 @@ particle_filter_state <- R6::R6Class(
     ##' value of `step_index`
     run = function() {
       if (is.null(private$compare)) {
-        particle_filter_compiled(self, private)
+        particle_filter_compiled(self, private, private$device)
       } else {
         self$step(private$n_steps)
       }
@@ -203,7 +205,7 @@ particle_filter_state <- R6::R6Class(
 
       for (t in seq(curr + 1L, step_index)) {
         step_end <- steps[t, 2L]
-        state <- model$run(step_end)
+        state <- model$run(step_end, device = private$device)
 
         if (save_history) {
           history_value[, , t + 1L] <- model$state(save_history_index)
@@ -269,6 +271,7 @@ particle_filter_state <- R6::R6Class(
     ##'
     ##' @param pars New model parameters
     fork = function(pars) {
+      stopifnot(!private$device) # this won't work
       seed <- self$model$rng_state()
       save_history <- !is.null(self$history)
       ret <- particle_filter_state$new(
@@ -291,7 +294,7 @@ particle_filter_state <- R6::R6Class(
 
 ## This is used by both the nested and non-nested particle filter, and
 ## outsources all the work to dust.
-particle_filter_compiled <- function(self, private) {
+particle_filter_compiled <- function(self, private, device = FALSE) {
   history <- self$history
   save_history <- !is.null(history)
   save_history_index <- self$history$index
@@ -302,7 +305,7 @@ particle_filter_compiled <- function(self, private) {
     on.exit(model$set_index(integer(0)))
   }
 
-  res <- model$filter(save_history, private$save_restart_step)
+  res <- model$filter(save_history, private$save_restart_step, private$device)
 
   self$log_likelihood_step <- NA_real_
   self$log_likelihood <- res$log_likelihood

--- a/R/particle_filter_state_nested.R
+++ b/R/particle_filter_state_nested.R
@@ -26,6 +26,7 @@ particle_filter_state_nested <- R6::R6Class(
     initial = NULL,
     index = NULL,
     compare = NULL,
+    device = NULL,
     save_restart_step = NULL,
     save_restart = NULL,
     current_step_index = 0L
@@ -60,8 +61,7 @@ particle_filter_state_nested <- R6::R6Class(
     ##' documented.
     initialize = function(pars, generator, model, data, data_split, steps,
                           n_particles, n_threads, initial, index, compare,
-                          seed, save_history, save_restart) {
-
+                          device, seed, save_history, save_restart) {
       ## NOTE: this will generate a warning when updating docs but
       ## that's ok; see https://github.com/r-lib/roxygen2/issues/1067
       if (length(pars) < length(unique(data$population))) {
@@ -137,6 +137,7 @@ particle_filter_state_nested <- R6::R6Class(
       private$initial <- initial
       private$index <- index
       private$compare <- compare
+      private$device <- device
       private$save_restart_step <- save_restart_step
       private$save_restart <- save_restart
 
@@ -150,7 +151,7 @@ particle_filter_state_nested <- R6::R6Class(
     ##' value of `step_index`
     run = function() {
       if (is.null(private$compare)) {
-        particle_filter_compiled(self, private)
+        particle_filter_compiled(self, private, private$device)
       } else {
         self$step(private$n_steps)
       }
@@ -211,7 +212,7 @@ particle_filter_state_nested <- R6::R6Class(
 
       for (t in seq(curr + 1L, step_index)) {
         step_end <- steps[t, 2L]
-        state <- model$run(step_end)
+        state <- model$run(step_end, device = private$device)
 
         if (save_history) {
           history_value[, , , t + 1L] <- model$state(save_history_index)

--- a/R/particle_filter_state_nested.R
+++ b/R/particle_filter_state_nested.R
@@ -61,7 +61,7 @@ particle_filter_state_nested <- R6::R6Class(
     ##' documented.
     initialize = function(pars, generator, model, data, data_split, steps,
                           n_particles, n_threads, initial, index, compare,
-                          device, seed, save_history, save_restart) {
+                          device_id, seed, save_history, save_restart) {
       ## NOTE: this will generate a warning when updating docs but
       ## that's ok; see https://github.com/r-lib/roxygen2/issues/1067
       if (length(pars) < length(unique(data$population))) {
@@ -74,7 +74,7 @@ particle_filter_state_nested <- R6::R6Class(
         model <- generator$new(pars = pars, step = steps[[1L]],
                                n_particles = n_particles,
                                n_threads = n_threads, seed = seed,
-                               pars_multi = TRUE)
+                               device_id = device_id, pars_multi = TRUE)
         if (is.null(compare)) {
           model$set_index(integer(0))
           model$set_data(data_split)
@@ -137,7 +137,7 @@ particle_filter_state_nested <- R6::R6Class(
       private$initial <- initial
       private$index <- index
       private$compare <- compare
-      private$device <- device
+      private$device <- !is.null(device_id)
       private$save_restart_step <- save_restart_step
       private$save_restart <- save_restart
 
@@ -289,13 +289,15 @@ particle_filter_state_nested <- R6::R6Class(
     ##'
     ##' @param pars New model parameters
     fork = function(pars) {
+      stopifnot(!private$device) # this won't work
+      device_id <- NULL
       seed <- self$model$rng_state()
       save_history <- !is.null(self$history)
       ret <- particle_filter_state_nested$new(
         pars, private$generator, NULL, private$data, private$data_split,
         private$steps, private$n_particles, private$n_threads,
-        private$initial, private$index, private$compare, seed,
-        save_history, private$save_restart)
+        private$initial, private$index, private$compare, device_id,
+        seed, save_history, private$save_restart)
 
       ## Run it up to the same point
       ret$step(private$current_step_index)

--- a/R/pmcmc_parallel.R
+++ b/R/pmcmc_parallel.R
@@ -316,7 +316,7 @@ pmcmc_parallel_progress <- function(control, force = FALSE) {
     t0 <- Sys.time()
     callback <- function(p) {
       message(sprintf("Finished %d steps in %s",
-                      n, format(Sys.time() - t0, digits = 0)))
+                      n, format(Sys.time() - t0, digits = 1)))
     }
     p <- progress::progress_bar$new(fmt, n, callback = callback, force = force)
     ## Progress likes to be started right away:

--- a/R/pmcmc_utils.R
+++ b/R/pmcmc_utils.R
@@ -83,7 +83,7 @@ pmcmc_progress <- function(n, show, force = FALSE) {
     t0 <- Sys.time()
     callback <- function(p) {
       message(sprintf("Finished %d steps in %s",
-                      n, format(Sys.time() - t0, digits = 0)))
+                      n, format(Sys.time() - t0, digits = 1)))
     }
     p <- progress::progress_bar$new(fmt, n, callback = callback, force = force)
     p$tick(0)

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -74,6 +74,14 @@ assert_scalar_positive_integer <- function(x, name = deparse(substitute(x))) {
 }
 
 
+assert_scalar_integer <- function(x, name = deparse(substitute(x))) {
+  force(name)
+  assert_scalar(x, name)
+  assert_integer(x, name)
+  invisible(x)
+}
+
+
 assert_scalar_logical <- function(x, name = deparse(substitute(x))) {
   force(name)
   assert_scalar(x, name)

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -97,7 +97,8 @@ Create the particle filter
   index = NULL,
   initial = NULL,
   n_threads = 1L,
-  seed = NULL
+  seed = NULL,
+  device_id = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -170,6 +171,14 @@ generator), a positive integer, or a raw vector - see \code{\link[dust:dust]{dus
 and \code{\link[dust:dust_rng]{dust::dust_rng}} for more details. Note that the random number
 stream is unrelated from R's random number generator, except for
 initialisation with \code{seed = NULL}.}
+
+\item{\code{device_id}}{Integer, indicating the device to use, where the
+model has GPU support. An error is thrown if the device id given
+is not reported to be available (note that CUDA numbers devices
+from 0, so that '0' is the first device, and so on). To see available
+device ids, you can run \code{model$public_methods$device_info()}.
+If \code{device_id} is non-NULL, then when your model calls methods
+\code{run} or \code{filter}, it will run on the GPU.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -66,6 +66,7 @@ documented.
   initial,
   index,
   compare,
+  device_id,
   seed,
   save_history,
   save_restart

--- a/man/particle_filter_state_nested.Rd
+++ b/man/particle_filter_state_nested.Rd
@@ -66,6 +66,7 @@ documented.
   initial,
   index,
   compare,
+  device,
   seed,
   save_history,
   save_restart

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -450,6 +450,7 @@ test_that("can return inputs", {
   expect_equal(inputs$n_particles, n_particles)
   expect_equal(inputs$index, dat$index)
   expect_equal(inputs$compare, dat$compare)
+  expect_null(inputs$device_id)
   expect_equal(inputs$initial, initial)
   expect_equal(inputs$seed, 100)
 

--- a/tests/testthat/test-pmcmc-parallel.R
+++ b/tests/testthat/test-pmcmc-parallel.R
@@ -49,12 +49,8 @@ test_that("Share out cores", {
 })
 
 
-## Currently failing on R-devel because of changes that restrict
-## assignment of the traceback (currently used by callr); see
-## https://github.com/r-lib/callr/issues/196
 test_that("throw from callr operation", {
   skip_on_cran()
-  skip_if(getRversion() > numeric_version("4.0.5"))
 
   dat <- example_sir()
   n_particles <- 42

--- a/tests/testthat/test-pmcmc-utils.R
+++ b/tests/testthat/test-pmcmc-utils.R
@@ -111,5 +111,5 @@ test_that("progress bar creates progress_bar when progress = TRUE", {
     "progress_bar")
   expect_message(
     p(),
-    "Finished 3 steps in [0-9]+ secs")
+    "Finished 3 steps in [0-9.]+ secs")
 })


### PR DESCRIPTION
This PR wires up the last bits to allow running a cuda-compiled model on a gpu

```r
path <- system.file("examples/sirs.cpp", package = "dust", mustWork = TRUE)

mod_d <- dust::dust_example("sirs")
mod_f <- dust::dust(path, real_t = "float", gpu = FALSE, workdir = "mod_f")
mod_g <- dust::dust(path, real_t = "float", gpu = TRUE, workdir = "mod_g")

date <- seq(0, 150)
steps_per_day <- 4
y <- mod_d$new(list(), 0, 1, seed = 1L)$simulate(date * steps_per_day)
incidence <- data.frame(date = date[-1], incidence = y[4, 1, -1])
data <- mcstate::particle_filter_data(incidence, "date", steps_per_day)

n_particles <- 100
p_d <- mcstate::particle_filter$new(data, mod_d, n_particles, NULL)
p_f <- mcstate::particle_filter$new(data, mod_f, n_particles, NULL)

res_d <- bench::press(
  n_particles = 2^(0:6) * 10,
  {
    p_d <- mcstate::particle_filter$new(data, mod_d, n_particles, NULL)
    bench::mark(
      p_d$run(list()),
      check = FALSE, memory = FALSE, min_iterations = 5)
  }
)

res_f <- bench::press(
  n_particles = 2^(0:6) * 10,
  {
    p_f <- mcstate::particle_filter$new(data, mod_f, n_particles, NULL)
    bench::mark(
      p_f$run(list()),
      check = FALSE, memory = FALSE, min_iterations = 5)
  }
)

res_g <- bench::press(
  n_particles = 2^(0:14) * 10,
  {
    p_g <- mcstate::particle_filter$new(data, mod_g, n_particles, NULL,
                                        device_id = 0L)
    bench::mark(
      p_g$run(list()),
      check = FALSE, memory = FALSE, min_iterations = 10)
  }
)

plot(median ~ n_particles, res_d, log = "xy", col = "red", type = "p",
     xlab = "Number of particles", ylab = "Time (s)",
     xlim = range(res_g$n_particles), ylim = range(res_d$median, res_g$median))
points(median ~ n_particles, res_f, col = "blue")
points(median ~ n_particles, res_g, col = "orange", pch = 19)
```