### PR TITLE
Allow particle filter early exit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.6.3
+Version: 0.6.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.6.4
+
+* Allow the particle filter to terminate early if we would not be interested in the result. This is useful for `mcstate::pmcmc` which can use it to stop calculating a likelood that would be rejected. Primarily useful when running with relatively low numbers of particles and a high variance in the estimator (#138)
+
 # mcstate 0.6.3
 
 * Add support for running in "deterministic" mode with recent dust (#139)

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -126,10 +126,15 @@ particle_deterministic <- R6::R6Class(
     ##' @param save_restart An integer vector of time points to save
     ##' restart infomation for. Not currently supported.
     ##'
+    ##' @param min_log_likelihood Not currently supported, exists to match
+    ##'   the inteface with [mcstate::particle_filter]. Providing a value
+    ##'   larger than -Inf will cause an error.
+    ##'
     ##' @return A single numeric value representing the log-likelihood
     ##' (`-Inf` if the model is impossible)
-    run = function(pars = list(), save_history = FALSE, save_restart = NULL) {
-      self$run_many(list(pars), save_history, save_restart)
+    run = function(pars = list(), save_history = FALSE, save_restart = NULL,
+                   min_log_likelihood = -Inf) {
+      self$run_many(list(pars), save_history, save_restart, min_log_likelihood)
     },
 
     ##' @description Run the deterministic particle filter on several
@@ -146,11 +151,19 @@ particle_deterministic <- R6::R6Class(
     ##' @param save_restart An integer vector of time points to save
     ##' restart infomation for. Not currently supported.
     ##'
+    ##' @param min_log_likelihood Not currently supported, exists to match
+    ##'   the inteface with [mcstate::particle_filter]. Providing a value
+    ##'   larger than -Inf will cause an error.
+    ##'
     ##' @return A numeric vector of values representing the log-likelihood
     ##' (`-Inf` if the model is impossible), one per parameter set
-    run_many = function(pars, save_history = FALSE, save_restart = NULL) {
+    run_many = function(pars, save_history = FALSE, save_restart = NULL,
+                        min_log_likelihood = -Inf) {
       if (!is.null(save_restart)) {
         stop("'save_restart' cannot be used with particle_deterministic")
+      }
+      if (min_log_likelihood > -Inf) {
+        stop("'min_log_likelihood' cannot be used with particle_deterministic")
       }
       n_particles <- length(pars)
       steps <- unname(as.matrix(private$data[c("step_start", "step_end")]))

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -303,6 +303,9 @@ particle_filter <- R6::R6Class(
     ##' @param save_restart Times to save restart state at. See `$run()` for
     ##' details.
     ##'
+    ##' @param min_log_likelihood Optionally, a numeric value representing the
+    ##' smallest likelihood we are interested in. See `$run()` for details.
+    ##'
     ##' @return An object of class `particle_filter_state`, with methods
     ##' `step` and `end`. This interface is still subject to change.
     run_begin = function(pars = list(), save_history = FALSE,

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -265,7 +265,7 @@ particle_filter <- R6::R6Class(
     ##' terms of steps. The state will be saved after the particle
     ##' filtering operation (i.e., at the end of the step).
     ##'
-    ##' @param min_likelihood Optionally, a numeric value representing the
+    ##' @param min_log_likelihood Optionally, a numeric value representing the
     ##' smallest likelihood we are interested in. If given and the particle
     ##' filter drops below this number, then we terminate early and return
     ##' `-Inf`. In this case, history and final state cannot be returned
@@ -279,9 +279,9 @@ particle_filter <- R6::R6Class(
     ##' @return A single numeric value representing the log-likelihood
     ##' (`-Inf` if the model is impossible)
     run = function(pars = list(), save_history = FALSE, save_restart = NULL,
-                   min_likelihood = NULL) {
+                   min_log_likelihood = NULL) {
       obj <- self$run_begin(pars, save_history, save_restart,
-                            min_likelihood = min_likelihood)
+                            min_log_likelihood = min_log_likelihood)
       obj$run()
       private$last_history <- obj$history
       private$last_model <- obj$model
@@ -306,8 +306,8 @@ particle_filter <- R6::R6Class(
     ##' @return An object of class `particle_filter_state`, with methods
     ##' `step` and `end`. This interface is still subject to change.
     run_begin = function(pars = list(), save_history = FALSE,
-                         save_restart = NULL, min_likelihood = NULL) {
-      min_likelihood <- min_likelihood %||% -Inf
+                         save_restart = NULL, min_log_likelihood = NULL) {
+      min_log_likelihood <- min_log_likelihood %||% -Inf
       if (private$nested) {
         particle_filter_state_nested$new(
           pars, self$model, private$last_model, private$data,
@@ -319,7 +319,7 @@ particle_filter <- R6::R6Class(
           pars, self$model, private$last_model, private$data,
           private$data_split, private$steps, self$n_particles,
           private$n_threads, private$initial, private$index, private$compare,
-          private$device_config, private$seed, min_likelihood,
+          private$device_config, private$seed, min_log_likelihood,
           save_history, save_restart)
       }
     },

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -288,7 +288,7 @@ particle_filter_state <- R6::R6Class(
         pars, private$generator, NULL, private$data, private$data_split,
         private$steps, private$n_particles, private$n_threads,
         private$initial, private$index, private$compare, device_config,
-        seed, save_history, private$save_restart)
+        seed, private$min_log_likelihood, save_history, private$save_restart)
 
       ## Run it up to the same point
       ret$step(private$current_step_index)

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -29,7 +29,7 @@ particle_filter_state <- R6::R6Class(
     device = NULL,
     save_restart_step = NULL,
     save_restart = NULL,
-    min_likelihood = NULL,
+    min_log_likelihood = NULL,
     current_step_index = 0L
   ),
 
@@ -62,7 +62,7 @@ particle_filter_state <- R6::R6Class(
     ##' documented.
     initialize = function(pars, generator, model, data, data_split, steps,
                           n_particles, n_threads, initial, index, compare,
-                          device_config, seed, min_likelihood,
+                          device_config, seed, min_log_likelihood,
                           save_history, save_restart) {
       ## NOTE: this will generate a warning when updating docs but
       ## that's ok; see https://github.com/r-lib/roxygen2/issues/1067
@@ -130,7 +130,7 @@ particle_filter_state <- R6::R6Class(
       private$index <- index
       private$compare <- compare
       private$device <- !is.null(device_config)
-      private$min_likelihood <- min_likelihood
+      private$min_log_likelihood <- min_log_likelihood
       private$save_restart_step <- save_restart_step
       private$save_restart <- save_restart
 
@@ -144,7 +144,7 @@ particle_filter_state <- R6::R6Class(
     ##' value of `step_index`
     run = function() {
       if (is.null(private$compare)) {
-        ## TODO: add min_likelihood support here, needs work in dust?
+        ## TODO: add min_log_likelihood support here, needs work in dust?
         particle_filter_compiled(self, private, private$device)
       } else {
         self$step(private$n_steps)
@@ -207,7 +207,7 @@ particle_filter_state <- R6::R6Class(
       log_likelihood <- self$log_likelihood
       n_particles <- private$n_particles
 
-      min_likelihood <- private$min_likelihood
+      min_log_likelihood <- private$min_log_likelihood
 
       for (t in seq(curr + 1L, step_index)) {
         step_end <- steps[t, 2L]
@@ -228,7 +228,7 @@ particle_filter_state <- R6::R6Class(
           weights <- scale_log_weights(log_weights)
           log_likelihood_step <- weights$average
           log_likelihood <- log_likelihood + log_likelihood_step
-          if (log_likelihood < min_likelihood) {
+          if (log_likelihood < min_log_likelihood) {
             log_likelihood <- -Inf
           }
           if (log_likelihood == -Inf) {

--- a/R/pmcmc_control.R
+++ b/R/pmcmc_control.R
@@ -117,6 +117,13 @@
 ##'   or on desired run-time, for example updating fixed parameters is
 ##'   quicker so more varied steps could be more efficient.
 ##'
+##' @param filter_early_exit Logical, indicating if we should allow
+##'   the particle filter to exit early for points that will not be
+##'   accepted. Only use this if your log-likelihood never increases
+##'   between steps. This will the the case where your likelihood
+##'   calculation is a sum of discrete normalised probability
+##'   distributions, but may not be for continuous distributions!
+##'
 ##' @return A `pmcmc_control` object, which should not be modified
 ##'   once created.
 ##'
@@ -142,7 +149,7 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
                           use_parallel_seed = FALSE,
                           save_state = TRUE, save_restart = NULL,
                           save_trajectories = FALSE, progress = FALSE,
-                          nested_step_ratio = 1) {
+                          nested_step_ratio = 1, filter_early_exit = FALSE) {
   assert_scalar_positive_integer(n_steps)
   assert_scalar_positive_integer(n_chains)
   assert_scalar_positive_integer(n_workers)
@@ -176,6 +183,7 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
   assert_scalar_logical(save_state)
   assert_scalar_logical(save_trajectories)
   assert_scalar_logical(progress)
+  assert_scalar_logical(filter_early_exit)
 
   if (n_chains < n_workers) {
     stop(sprintf("'n_chains' (%d) is less than 'n_workers' (%d)",
@@ -205,6 +213,7 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
               save_restart = save_restart,
               save_trajectories = save_trajectories,
               progress = progress,
+              filter_early_exit = filter_early_exit,
               nested_step_ratio = nested_step_ratio)
   class(ret) <- "pmcmc_control"
   ret

--- a/R/pmcmc_state.R
+++ b/R/pmcmc_state.R
@@ -66,12 +66,11 @@ pmcmc_state <- R6::R6Class(
       }
     },
 
-    ## TODO: change, everywhere, min_likelhood => min_loglikelihood
-    run_filter = function(p, min_likelihood = -Inf) {
+    run_filter = function(p, min_log_likelihood = -Inf) {
       private$filter$run(private$pars$model(p),
                          private$control$save_trajectories,
                          private$control$save_restart,
-                         min_likelihood)
+                         min_log_likelihood)
     },
 
     run_filter_nested = function(p) {

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -194,7 +194,12 @@ list will be added in a future version!}
 \subsection{Method \code{run()}}{
 Run the particle filter
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run(pars = list(), save_history = FALSE, save_restart = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$run(
+  pars = list(),
+  save_history = FALSE,
+  save_restart = NULL,
+  min_log_likelihood = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -219,6 +224,17 @@ restart infomation for. These are in terms of your underlying time
 variable (the \code{time} column in \code{\link[=particle_filter_data]{particle_filter_data()}}) not in
 terms of steps. The state will be saved after the particle
 filtering operation (i.e., at the end of the step).}
+
+\item{\code{min_log_likelihood}}{Optionally, a numeric value representing the
+smallest likelihood we are interested in. If given and the particle
+filter drops below this number, then we terminate early and return
+\code{-Inf}. In this case, history and final state cannot be returned
+from the filter. This is primarily intended for use with
+\link{pmcmc} where we can avoid computing likelihoods that
+will certainly be rejected. Only suitable for use where
+log-likelihood increments (with the \code{compare} function) are always
+negative. This is the case if you use a normalised discrete
+distribution, but not necessarily otherwise.}
 }
 \if{html}{\out{</div>}}
 }
@@ -240,7 +256,8 @@ as many steps as needed with \verb{$step()}.
 \if{html}{\out{<div class="r">}}\preformatted{particle_filter$run_begin(
   pars = list(),
   save_history = FALSE,
-  save_restart = NULL
+  save_restart = NULL,
+  min_log_likelihood = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -254,6 +271,9 @@ particles should be saved. See \verb{$run()} for details.}
 
 \item{\code{save_restart}}{Times to save restart state at. See \verb{$run()} for
 details.}
+
+\item{\code{min_log_likelihood}}{Optionally, a numeric value representing the
+smallest likelihood we are interested in. See \verb{$run()} for details.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -68,6 +68,7 @@ documented.
   compare,
   device_config,
   seed,
+  min_log_likelihood,
   save_history,
   save_restart
 )}\if{html}{\out{</div>}}

--- a/man/pmcmc_control.Rd
+++ b/man/pmcmc_control.Rd
@@ -17,7 +17,8 @@ pmcmc_control(
   save_restart = NULL,
   save_trajectories = FALSE,
   progress = FALSE,
-  nested_step_ratio = 1
+  nested_step_ratio = 1,
+  filter_early_exit = FALSE
 )
 }
 \arguments{
@@ -125,6 +126,13 @@ iterations updating the fixed and varied parameters. Sensible choices
 of this parameter may depend on the true ratio of fixed:varied parameters
 or on desired run-time, for example updating fixed parameters is
 quicker so more varied steps could be more efficient.}
+
+\item{filter_early_exit}{Logical, indicating if we should allow
+the particle filter to exit early for points that will not be
+accepted. Only use this if your log-likelihood never increases
+between steps. This will the the case where your likelihood
+calculation is a sum of discrete normalised probability
+distributions, but may not be for continuous distributions!}
 }
 \value{
 A \code{pmcmc_control} object, which should not be modified

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -67,8 +67,17 @@ test_that("can't restart deterministic filter", {
   dat <- example_sir()
   p <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
   expect_error(
-    p$run(pars, save_restart = c(100, 200)),
+    p$run(list(), save_restart = c(100, 200)),
     "'save_restart' cannot be used with particle_deterministic")
+})
+
+
+test_that("can't use min_log_likelihood with deterministic filter", {
+  dat <- example_sir()
+  p <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
+  expect_error(
+    p$run(list(), min_log_likelihood = -200),
+    "'min_log_likelihood' cannot be used with particle_deterministic")
 })
 
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1394,3 +1394,22 @@ test_that("Can run a gpu model by passing device through", {
   expect_false(mockery::mock_args(target_c)[[1]][[3]])
   expect_true(mockery::mock_args(target_g)[[1]][[3]])
 })
+
+
+test_that("Can terminate a filter early", {
+  dat <- example_sir()
+  n_particles <- 42
+  ## First run through, we'll get our cutoffs:
+  set.seed(1)
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index, seed = 1L)
+  ll1 <- replicate(10, p1$run())
+
+  set.seed(1)
+  p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index, seed = 1L)
+  min_ll <- mean(ll1)
+  ll2 <- replicate(10, p2$run(min_likelihood = min_ll))
+  expect_true(-Inf %in% ll2)
+  expect_true(min(ll2[is.finite(ll2)]) >= min_ll)
+})

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1409,7 +1409,7 @@ test_that("Can terminate a filter early", {
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index, seed = 1L)
   min_ll <- mean(ll1)
-  ll2 <- replicate(10, p2$run(min_likelihood = min_ll))
+  ll2 <- replicate(10, p2$run(min_log_likelihood = min_ll))
   expect_true(-Inf %in% ll2)
   expect_true(min(ll2[is.finite(ll2)]) >= min_ll)
 })

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -1069,3 +1069,26 @@ test_that("Split chain and write to file", {
 
   expect_equal(res1, res2)
 })
+
+
+test_that("Can run pmcmc with early exit enabled", {
+  dat <- example_sir()
+  ## Really low particle number to inflate variance and cause more
+  ## serious drop-outs
+  n_particles <- 5
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index, seed = 1L)
+  p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index, seed = 1L)
+  control1 <- pmcmc_control(30)
+  control2 <- pmcmc_control(30, filter_early_exit = TRUE)
+  set.seed(1)
+  system.time(res1 <- pmcmc(dat$pars, p1, control = control1))
+  set.seed(1)
+  system.time(res2 <- pmcmc(dat$pars, p2, control = control2))
+
+  ## Really hard to test this, the final parameters turn out to be
+  ## identical to 300 steps at least, which is surprising. However,
+  ## you can see that the RNG streams differ:
+  expect_false(identical(p2$inputs()$seed, p1$inputs()$seed))
+})


### PR DESCRIPTION
If the log-likelihood calculation proceeds by adding only negative numbers, then when running a pmcmc we can tell when we would not be interested in the result as it will be certainly rejected. This PR implements support for this, with two components:

* an argument `min_log_likelihood` to the `mcstate::particle_filter`'s `$run()` method, which returns `-Inf` at the point where the likelihood becomes too small
* some logic changes to pmcmc to compute the minimum acceptable likelihood (this rearranges the usual MH acceptance step slightly)

~I've not run this on sircovid yet, but based on some experimentation I think we should see something like a 10% speed increased given the excessive variance~
Preliminary runs on sircovid suggest it's highly chain dependent, with an average of ~10% across 3 chains that I tried. Total configuration change is to set `filter_early_exit = TRUE` to the pmcmc_control call in spimalot.

~Builds on and so requires #140~
Fixes #138 
