### PR TITLE
Increase session timeout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.6.5
+Version: 0.6.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc_parallel.R
+++ b/R/pmcmc_parallel.R
@@ -152,10 +152,10 @@ pmcmc_remote <- R6::R6Class(
       lockBinding("session", self)
     },
 
-    ## 3000ms is the timeout for the session to come alive; an error
+    ## 30000ms is the timeout for the session to come alive; an error
     ## will be thrown if it is not alive by then (this number is used
     ## by callr internally)
-    wait_session_ready = function(timeout = 3000) {
+    wait_session_ready = function(timeout = 30000) {
       self$session$poll_process(timeout)
       self$session$read()
       TRUE


### PR DESCRIPTION
try to avoid the session timeout

I think that since #143 we're getting longer timeouts because the hook (which loads inputs) is included in the timeout.