### PR TITLE
Allow safer running after pmcmc control modification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.6.6
+Version: 0.6.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -174,6 +174,10 @@ pmcmc_multiple_series <- function(pars, initial, filter, control) {
   }
   samples <- vector("list", control$n_chains)
 
+  ## Ensure that even if the control object has been updated we don't
+  ## do anything impossible:
+  control$n_steps_each <- control$n_steps
+
   for (i in seq_along(samples)) {
     samples[[i]] <- pmcmc_run_chain(i, pars, initial, filter, control, seed)
   }

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -1092,3 +1092,16 @@ test_that("Can run pmcmc with early exit enabled", {
   ## you can see that the RNG streams differ:
   expect_false(identical(p2$inputs()$seed, p1$inputs()$seed))
 })
+
+
+test_that("Fix impossible control parameters", {
+  ctrl <- pmcmc_control(10, n_workers = 1)
+  ctrl$n_steps_each <- 2
+  dat <- example_sir()
+  p <- particle_filter$new(dat$data, dat$model, 20, dat$compare,
+                           index = dat$index, seed = 1L)
+  ## Previously this errored, here we're just looking for completion
+  results <- pmcmc(dat$pars, p, control = ctrl)
+  expect_equal(dim(results$pars), c(11, 2))
+  expect_false(any(is.na(results$pars)))
+})


### PR DESCRIPTION
This fixes an issue seen by Ed where if manually tweaking the control object to go from using >1 worker to 1 we fail with the obscure error message:

```
> samples <- spimalot::spim_pmcmc(pars, p, control$pmcmc)
Running chains - this will take a while!
Running chain 1 / 1
Step 500 / 1500 [======================>----------------------------------------------] ETA  6m | 00:02:50 so farError in list_to_matrix(private$history_pars$get()) :
  all(len == len[[1]]) is not TRUE
```

This PR ensures that n_steps_each = n_steps in that case