### PR TITLE
Start on deterministic restart

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.6.12
+Version: 0.6.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.6.13
+
+* Allow saving restart from the deterministic filter (#153)
+
 # mcstate 0.6.5
 
 * Reduced overhead in parallel pmcmc with workers, and faster/less memory-hungry chain combination (#142)

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -318,11 +318,12 @@ particle_deterministic <- R6::R6Class(
         ## NOTE: anything other than 1 here will go poorly; we might
         ## replace with rep(1, length(restart_state)) or at least
         ## validate?
-        if (length(dim(restart_state)) == 4) {
-          restart_state <- restart_state[, index_particle, , , drop = FALSE]
-        } else {
-          restart_state <- restart_state[, index_particle, , drop = FALSE]
-        }
+        ##
+        ## TODO: nested deterministic filter is not supported so this
+        ## is always TRUE; see stochastic filter for the logic when
+        ## this is enabled.
+        stopifnot(length(dim(restart_state)) == 3)
+        restart_state <- restart_state[, index_particle, , drop = FALSE]
       }
       restart_state
     },

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -206,10 +206,12 @@ particle_deterministic <- R6::R6Class(
         for (i in seq_along(steps_split)) {
           y[[i]] <- model$simulate(steps_split[[i]])
           if (i <= length(save_restart)) {
-            restart_state[[i]] <- model$state()
+            s <- model$state()
+            restart_state[[i]] <- array_reshape(s, 1, c(nrow(s), 1))
           }
         }
         y <- array_bind(arrays = y)
+        restart_state <- array_bind(arrays = restart_state)
       }
 
       if (is.null(index)) {
@@ -304,6 +306,7 @@ particle_deterministic <- R6::R6Class(
     ##' interface.
     restart_state = function(index_particle = NULL) {
       if (is.null(private$last_model)) {
+        ## uncovered
         stop("Model has not yet been run")
       }
       restart_state <- private$last_restart_state
@@ -311,6 +314,7 @@ particle_deterministic <- R6::R6Class(
         stop("Can't get history as model was run with save_restart = NULL")
       }
       if (!is.null(index_particle)) {
+        ## uncovered
         ## NOTE: anything other than 1 here will go poorly; we might
         ## replace with rep(1, length(restart_state)) or at least
         ## validate?

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -159,9 +159,6 @@ particle_deterministic <- R6::R6Class(
     ##' (`-Inf` if the model is impossible), one per parameter set
     run_many = function(pars, save_history = FALSE, save_restart = NULL,
                         min_log_likelihood = -Inf) {
-      if (!is.null(save_restart)) {
-        stop("'save_restart' cannot be used with particle_deterministic")
-      }
       if (min_log_likelihood > -Inf) {
         stop("'min_log_likelihood' cannot be used with particle_deterministic")
       }
@@ -198,7 +195,22 @@ particle_deterministic <- R6::R6Class(
         model$set_index(index$index)
       }
 
-      y <- model$simulate(c(steps[[1]], steps[, 2]))
+      if (is.null(save_restart)) {
+        y <- model$simulate(c(steps[[1]], steps[, 2]))
+        restart_state <- NULL
+      } else {
+        steps_split <- deterministic_steps_restart(steps, save_restart,
+                                                   private$data)
+        restart_state <- vector("list", length(save_restart))
+        y <- vector("list", length(steps_split))
+        for (i in seq_along(steps_split)) {
+          y[[i]] <- model$simulate(steps_split[[i]])
+          if (i <= length(save_restart)) {
+            restart_state[[i]] <- model$state()
+          }
+        }
+        y <- array_bind(arrays = y)
+      }
 
       if (is.null(index)) {
         y_compare <- y
@@ -224,6 +236,7 @@ particle_deterministic <- R6::R6Class(
 
       private$last_model <- model
       private$last_history <- history
+      private$last_restart_state <- restart_state
 
       ll
     },
@@ -270,6 +283,47 @@ particle_deterministic <- R6::R6Class(
     },
 
     ##' @description
+    ##' Return the full particle filter state at points back in time
+    ##' that were saved with the `save_restart` argument to
+    ##' `$run()`. If available, this will return a 3d array, with
+    ##' dimensions representing (1) particle state, (2) particle index,
+    ##' (3) time point. If nested parameters are used then returns a 4d array,
+    ##' with dimensions representing (1) particle state, (2) particle index,
+    ##' (3) population, (4) time point. This could be quite large, especially
+    ##' if you are using the `index` argument to create the particle filter
+    ##' and return a subset of all state generally. In the stochastic version,
+    ##' this is different the saved trajectories returned by `$history()`
+    ##' because earlier saved state is not filtered by later filtering,
+    ##' but in the deterministic model we run with a single particle so it
+    ##' *is* the same.
+    ##'
+    ##' @param index_particle Optional vector of particle indices to return.
+    ##' If `NULL` we return all particles' states. Practically because the
+    ##' only valid value of index_particle is "1", this has no effect and
+    ##' it is included primarily for compatibility with the stochastic
+    ##' interface.
+    restart_state = function(index_particle = NULL) {
+      if (is.null(private$last_model)) {
+        stop("Model has not yet been run")
+      }
+      restart_state <- private$last_restart_state
+      if (is.null(restart_state)) {
+        stop("Can't get history as model was run with save_restart = NULL")
+      }
+      if (!is.null(index_particle)) {
+        ## NOTE: anything other than 1 here will go poorly; we might
+        ## replace with rep(1, length(restart_state)) or at least
+        ## validate?
+        if (length(dim(restart_state)) == 4) {
+          restart_state <- restart_state[, index_particle, , , drop = FALSE]
+        } else {
+          restart_state <- restart_state[, index_particle, , drop = FALSE]
+        }
+      }
+      restart_state
+    },
+
+    ##' @description
     ##' Return a list of inputs used to configure the deterministic particle
     ##' filter. These correspond directly to the argument names for the
     ##' constructor and are the same as the input arguments.
@@ -280,7 +334,7 @@ particle_deterministic <- R6::R6Class(
            initial = private$initial,
            compare = private$compare,
            n_threads = private$n_threads,
-           seed = filter_current_seed(private$last_model, private$seed))
+           seed = filter_current_seed(private$last_model, NULL))
     },
 
     ##' @description
@@ -313,7 +367,8 @@ particle_deterministic <- R6::R6Class(
     index = NULL,
     compare = NULL,
     last_model = NULL,
-    last_history = NULL
+    last_history = NULL,
+    last_restart_state = NULL
   ))
 
 
@@ -354,4 +409,17 @@ deterministic_initial <- function(pars, initial, info) {
   }
 
   ret
+}
+
+
+deterministic_steps_restart <- function(steps, save_restart, data) {
+  save_restart_step <- check_save_restart(save_restart, data)
+  i <- match(save_restart_step, steps[, 2])
+  if (last(i) < nrow(steps)) {
+    i <- c(i, nrow(steps))
+  }
+  j <- rep(seq_along(i), diff(c(0, i)))
+  steps_split <- unname(split(steps[, 2], j))
+  steps_split[[1]] <- c(steps[[1]], steps_split[[1]])
+  steps_split
 }

--- a/R/pmcmc_state.R
+++ b/R/pmcmc_state.R
@@ -32,6 +32,10 @@ pmcmc_state <- R6::R6Class(
         if (private$control$save_state) {
           private$curr_state <- private$filter$state()
         }
+        if (length(private$control$save_restart) > 0) {
+          private$curr_restart <- private$filter$restart_state()
+          dim(private$curr_restart) <- dim(private$curr_restart)[-2L]
+        }
       } else {
         i <- sample.int(private$filter$n_particles, 1)
         if (private$control$save_trajectories) {

--- a/man/particle_deterministic.Rd
+++ b/man/particle_deterministic.Rd
@@ -24,6 +24,7 @@ re-bound)}
 \item \href{#method-run_many}{\code{particle_deterministic$run_many()}}
 \item \href{#method-state}{\code{particle_deterministic$state()}}
 \item \href{#method-history}{\code{particle_deterministic$history()}}
+\item \href{#method-restart_state}{\code{particle_deterministic$restart_state()}}
 \item \href{#method-inputs}{\code{particle_deterministic$inputs()}}
 \item \href{#method-set_n_threads}{\code{particle_deterministic$set_n_threads()}}
 }
@@ -236,6 +237,39 @@ time point.
 \describe{
 \item{\code{index_particle}}{Optional vector of particle indices to return.
 If \code{NULL} we return all particles' histories.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-restart_state"></a>}}
+\if{latex}{\out{\hypertarget{method-restart_state}{}}}
+\subsection{Method \code{restart_state()}}{
+Return the full particle filter state at points back in time
+that were saved with the \code{save_restart} argument to
+\verb{$run()}. If available, this will return a 3d array, with
+dimensions representing (1) particle state, (2) particle index,
+(3) time point. If nested parameters are used then returns a 4d array,
+with dimensions representing (1) particle state, (2) particle index,
+(3) population, (4) time point. This could be quite large, especially
+if you are using the \code{index} argument to create the particle filter
+and return a subset of all state generally. In the stochastic version,
+this is different the saved trajectories returned by \verb{$history()}
+because earlier saved state is not filtered by later filtering,
+but in the deterministic model we run with a single particle so it
+\emph{is} the same.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{particle_deterministic$restart_state(index_particle = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index_particle}}{Optional vector of particle indices to return.
+If \code{NULL} we return all particles' states. Practically because the
+only valid value of index_particle is "1", this has no effect and
+it is included primarily for compatibility with the stochastic
+interface.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -63,10 +63,12 @@ test_that("Control the initial conditions", {
 })
 
 
-test_that("can't restart deterministic filter", {
+test_that("can collect restart from deterministic filter", {
   dat <- example_sir()
   set.seed(1)
   p1 <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
+  expect_error(p1$restart_state(),
+               "Model has not yet been run")
   res1 <- p1$run(list())
 
   set.seed(1)
@@ -79,10 +81,12 @@ test_that("can't restart deterministic filter", {
 
   h <- p2$history()
   r <- p2$restart_state()
-  expect_type(r, "list")
-  expect_length(r, 2)
-  expect_equal(h[, , 26], r[[1]][1:3])
-  expect_equal(h[, , 51], r[[2]][1:3])
+  expect_equal(dim(r), c(5, 1, 2))
+  expect_equal(h[, , 26], r[1:3, 1, 1])
+  expect_equal(h[, , 51], r[1:3, 1, 2])
+
+  ## Can resample correctly:
+  expect_equal(p2$restart_state(1L), p2$restart_state())
 })
 
 

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -65,10 +65,24 @@ test_that("Control the initial conditions", {
 
 test_that("can't restart deterministic filter", {
   dat <- example_sir()
-  p <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
-  expect_error(
-    p$run(list(), save_restart = c(100, 200)),
-    "'save_restart' cannot be used with particle_deterministic")
+  set.seed(1)
+  p1 <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
+  res1 <- p1$run(list())
+
+  set.seed(1)
+  p2 <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
+  res2 <- p2$run(list(), save_restart = c(25, 50), save_history = TRUE)
+
+  expect_equal(res1, res2)
+  expect_error(p1$restart_state(),
+               "Can't get history as model was run with save_restart = NULL")
+
+  h <- p2$history()
+  r <- p2$restart_state()
+  expect_type(r, "list")
+  expect_length(r, 2)
+  expect_equal(h[, , 26], r[[1]][1:3])
+  expect_equal(h[, , 51], r[[2]][1:3])
 })
 
 

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -1105,3 +1105,42 @@ test_that("Fix impossible control parameters", {
   expect_equal(dim(results$pars), c(11, 2))
   expect_false(any(is.na(results$pars)))
 })
+
+
+test_that("Can save intermediate state to restart", {
+  dat <- example_sir()
+  p1 <- particle_deterministic$new(dat$data, dat$model, dat$compare,
+                                   index = dat$index)
+  p2 <- particle_deterministic$new(dat$data, dat$model, dat$compare,
+                                   index = dat$index)
+  p3 <- particle_deterministic$new(dat$data, dat$model, dat$compare,
+                                   index = dat$index)
+  control1 <- pmcmc_control(30, save_trajectories = TRUE, save_state = TRUE)
+  control2 <- pmcmc_control(30, save_trajectories = TRUE, save_state = TRUE,
+                            save_restart = 20)
+  control3 <- pmcmc_control(30, save_trajectories = TRUE, save_state = TRUE,
+                            save_restart = c(20, 30))
+
+  set.seed(1)
+  res1 <- pmcmc(dat$pars, p1, control = control1)
+  set.seed(1)
+  res2 <- pmcmc(dat$pars, p2, control = control2)
+  set.seed(1)
+  res3 <- pmcmc(dat$pars, p3, control = control3)
+
+  ## Same actual run
+  expect_identical(res1$trajectories, res2$trajectories)
+  expect_identical(res1$trajectories, res3$trajectories)
+
+  expect_null(res1$restart)
+
+  expect_is(res2$restart, "list")
+  expect_equal(res2$restart$time, 20)
+  expect_equal(dim(res2$restart$state), c(5, 31, 1))
+
+  expect_is(res3$restart, "list")
+  expect_equal(res3$restart$time, c(20, 30))
+  expect_equal(dim(res3$restart$state), c(5, 31, 2))
+
+  expect_equal(res3$restart$state[, , 1], res2$restart$state[, , 1])
+})


### PR DESCRIPTION
Implement restart for deterministic model fit. Should have the same interface as the stochastic model

Install with

```
remotes::install_github("mrc-ide/mcstate@i153-deterministic-restart", upgrade = FALSE)
```

and try and get the next task working, please report back any issues