### PR TITLE
Update to use new distributed seeding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
     callr (>= 3.7.0),
-    dust (>= 0.11.16),
+    dust (>= 0.11.15),
     processx,
     progress (>= 1.2.0)
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.6.15
+Version: 0.6.16
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.6.14
+Version: 0.6.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),
@@ -23,7 +23,7 @@ BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
     callr (>= 3.7.0),
-    dust (>= 0.11.5),
+    dust (>= 0.11.16),
     processx,
     progress (>= 1.2.0)
 Suggests:
@@ -34,7 +34,7 @@ Suggests:
     knitr,
     mockery,
     mvtnorm,
-    odin.dust (>= 0.2.13),
+    odin.dust (>= 0.2.14),
     rmarkdown,
     testthat,
     withr

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -104,6 +104,8 @@ particle_deterministic <- R6::R6Class(
         private$initial <- assert_function(initial)
       }
       private$n_threads <- n_threads
+
+      self$model <- model
       lockBinding("model", self)
     },
 

--- a/R/pmcmc.R
+++ b/R/pmcmc.R
@@ -103,7 +103,7 @@ pmcmc_chains_prepare <- function(pars, filter, initial = NULL, control = NULL) {
     initial <- pmcmc_check_initial(initial, pars, control$n_chains)
   }
 
-  seed <- make_seeds(control$n_chains, filter$inputs()$seed)
+  seed <- make_seeds(control$n_chains, filter$inputs()$seed, filter$model)
 
   ret <- list(pars = pars, initial = initial, filter = filter,
               control = control, seed = seed)
@@ -168,7 +168,7 @@ pmcmc_single_chain_nested <- function(pars, initial, filter, control,
 
 pmcmc_multiple_series <- function(pars, initial, filter, control) {
   if (control$use_parallel_seed) {
-    seed <- make_seeds(control$n_chains, filter$inputs()$seed)
+    seed <- make_seeds(control$n_chains, filter$inputs()$seed, filter$model)
   } else {
     seed <- NULL
   }

--- a/R/pmcmc_parallel.R
+++ b/R/pmcmc_parallel.R
@@ -251,11 +251,18 @@ make_seeds <- function(n, seed, model) {
 
   seed_dust <- dust::dust_rng_distributed_state(seed, n_streams, n, model)
 
-  ## Grab another source of independent numbers to create the R seeds
-  ## with by doing one further long jump from the last state
+  ## Grab another source of independent numbers to create the R
+  ## seeds. This is essentially (though not identically) the behaviour
+  ## of mcstate <= 0.6.16 which drew one number for the R seed from
+  ## each generator but here we draw them all from the first.
   ##
-  ## Using integers on 1..2^24 (16777216) for the R seed as always
-  ## integer representable.
+  ## An alternative approach would be to take one long jump then
+  ## generate seeds from that independent generator, but that has the
+  ## downside of the R seed for each chain being dependent on the
+  ## number of chains run.
+  ##
+  ## We rescale the real number to an integer on 1..2^24 (16777216)
+  ## for the R seed as this will always integer representable.
   rng <- dust::dust_rng$new(seed_dust[[1]])$long_jump()
   seed_r <- ceiling(rng$random_real(n) * 2^24)
 

--- a/R/pmcmc_parallel.R
+++ b/R/pmcmc_parallel.R
@@ -25,7 +25,7 @@ pmcmc_orchestrator <- R6::R6Class(
       private$progress <- pmcmc_parallel_progress(control)
 
       filter_inputs <- filter$inputs()
-      seed <- make_seeds(control$n_chains, filter_inputs$seed)
+      seed <- make_seeds(control$n_chains, filter_inputs$seed, filter$model)
       filter_inputs$n_threads <- private$thread_pool$target
 
       private$remotes <- vector("list", control$n_workers)
@@ -241,20 +241,25 @@ pmcmc_remote <- R6::R6Class(
 ## single seed, which is itself sensibly chosen. Whether or not this
 ## leads to a sensible initialisation for R's RNG is a different
 ## question, but this should do as well as most reasonable attempts.
-make_seeds <- function(n, seed) {
-  ret <- vector("list", n)
+make_seeds <- function(n, seed, model) {
   n_streams <- 1L
   if (is.raw(seed)) {
+    ## This is not always correct and varies with the model; move to
+    ## make this explicit I think in the next step.
     n_streams <- length(seed) / 32L # 4 uint64_t, each 8 bytes
   }
-  rng <- dust::dust_rng$new(seed, n_streams)
-  for (i in seq_len(n)) {
-    state <- rng$state()
-    ret[[i]] <- list(dust = state,
-                     r = rng$random_real(1) * .Machine$integer.max)
-    rng$long_jump()
-  }
-  ret
+
+  seed_dust <- dust::dust_rng_distributed_state(seed, n_streams, n, model)
+
+  ## Grab another source of independent numbers to create the R seeds
+  ## with by doing one further long jump from the last state
+  ##
+  ## Using integers on 1..2^24 (16777216) for the R seed as always
+  ## integer representable.
+  rng <- dust::dust_rng$new(seed_dust[[1]])$long_jump()
+  seed_r <- ceiling(rng$random_real(n) * 2^24)
+
+  Map(list, dust = seed_dust, r = seed_r)
 }
 
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -25,10 +25,9 @@
 ##'   pass in `seed = object$predict$seed`. However, do not do this if
 ##'   you are gong to run `pmcmc_predict()` multiple times the result
 ##'   will be identical. If you do want to call predict with this
-##'   state multiple times you should call
-##'   [dust::dust_rng_state_long_jump()] with a `times` argument of `i`
-##'   for the `i`'th usage (i.e., once for the first usage,
-##'   two times for the 2nd, etc).
+##'   state multiple times you should create a persistant rng state
+##'   object (e.g., with [dust::dust_rng] and perform a "long jump"
+##'   between each call.
 ##'
 ##' @param prepend_trajectories Prepend trajectories from the particle
 ##'   filter to the predictions created here.

--- a/R/smc2.R
+++ b/R/smc2.R
@@ -68,14 +68,16 @@ smc2_engine <- R6::R6Class(
       ## TODO: fix this in dust to make it easier to get a
       ## "reasonable" state. We might also advance the state with a
       ## long jump first?
-      seed <- dust::dust_rng$new(inputs$seed)$state()
+      seed <- dust::dust_rng_distributed_state(inputs$seed,
+                                               inputs$n_particles,
+                                               control$n_parameter_sets,
+                                               inputs$model)
       filters <- vector("list", control$n_parameter_sets)
       pars_model <- pars$model(theta)
       for (i in seq_len(control$n_parameter_sets)) {
-        seed <- dust::dust_rng_state_long_jump(seed)
         f <- particle_filter$new(
           inputs$data, inputs$model, inputs$n_particles, inputs$compare,
-          inputs$index, inputs$initial, inputs$n_threads, seed)
+          inputs$index, inputs$initial, inputs$n_threads, seed[[i]])
         filters[[i]] <- f$run_begin(pars_model[[i]], control$save_trajectories)
       }
 

--- a/man/pmcmc_predict.Rd
+++ b/man/pmcmc_predict.Rd
@@ -37,10 +37,9 @@ pick up from the same RNG stream used in the simulation if you
 pass in \code{seed = object$predict$seed}. However, do not do this if
 you are gong to run \code{pmcmc_predict()} multiple times the result
 will be identical. If you do want to call predict with this
-state multiple times you should call
-\code{\link[dust:dust_rng_state_long_jump]{dust::dust_rng_state_long_jump()}} with a \code{times} argument of \code{i}
-for the \code{i}'th usage (i.e., once for the first usage,
-two times for the 2nd, etc).}
+state multiple times you should create a persistant rng state
+object (e.g., with \link[dust:dust_rng]{dust::dust_rng} and perform a "long jump"
+between each call.}
 }
 \description{
 Run predictions from the results of \code{\link[=pmcmc]{pmcmc()}}. This

--- a/tests/testthat/test-pmcmc-parallel.R
+++ b/tests/testthat/test-pmcmc-parallel.R
@@ -13,7 +13,7 @@ test_that("basic parallel operation", {
   ans <- pmcmc(dat$pars, p0, control = control)
 
   ## Run two chains manually with a given pair of seeds:
-  s <- make_seeds(n_chains, 1L)
+  s <- make_seeds(n_chains, 1L, dat$model)
   f <- function(idx) {
     set.seed(s[[idx]]$r)
     p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
@@ -62,7 +62,7 @@ test_that("throw from callr operation", {
                            n_steps_each = 5)
 
   initial <- pmcmc_check_initial(NULL, dat$pars, n_chains)
-  seed <- make_seeds(n_chains, NULL)
+  seed <- make_seeds(n_chains, NULL, dat$model)
 
   control$n_workers <- 0
   obj <- pmcmc_orchestrator$new(dat$pars, initial, p0, control)
@@ -98,19 +98,21 @@ test_that("running pmcmc with progress = TRUE prints messages", {
 
 
 test_that("make seeds with integer returns length-32 raws", {
-  s <- make_seeds(2, 1)
+  algorithm <- "xoshiro256plus"
+  s <- make_seeds(2, 1, algorithm)
   expect_length(s, 2L)
   expect_setequal(names(s[[1]]), c("dust", "r"))
   expect_length(s[[1]]$dust, 32L)
   expect_is(s[[1]]$dust, "raw")
-  expect_identical(make_seeds(2, 1), s)
-  expect_identical(make_seeds(4, 1)[1:2], s)
+  expect_identical(make_seeds(2, 1, algorithm), s)
+  expect_identical(make_seeds(4, 1, algorithm)[1:2], s)
 })
 
 
 test_that("make seeds with long raw retains size", {
+  algorithm <- "xoshiro256plus"
   seed <- dust::dust_rng$new(NULL, n_streams = 3)$state()
-  s <- make_seeds(2L, seed)
+  s <- make_seeds(2L, seed, algorithm)
   expect_length(s, 2L)
   expect_setequal(names(s[[1]]), c("dust", "r"))
   expect_identical(s[[1]]$dust, seed)
@@ -266,7 +268,7 @@ test_that("basic parallel operation nested", {
   ans <- pmcmc(pars, p0, control = control)
 
   ## Run two chains manually with a given pair of seeds:
-  s <- make_seeds(n_chains, 1L)
+  s <- make_seeds(n_chains, 1L, dat$model)
   f <- function(idx) {
     set.seed(s[[idx]]$r)
     p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,


### PR DESCRIPTION
Uses code introduced in https://github.com/mrc-ide/dust/pull/345 and allows us to remove the ad-hoc function (which was problematic with floats and non-default rng algorithms; see https://github.com/mrc-ide/dust/issues/343)

Fixes #155 