### PR TITLE
Fix stage filtering on restart

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -17,7 +17,7 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest,   r: 'oldrel'}
+          # - {os: macOS-latest,   r: 'oldrel'}
           - {os: windows-latest, r: 'oldrel'}
 
     env:
@@ -134,15 +134,15 @@ jobs:
           asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.zip
           asset_content_type: application/zip
 
-      - name: Upload macOS binary
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: pkg/pkg-macOS-latest-oldrel/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
-          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}_oldrel.tar.gz
-          asset_content_type: application/gzip
+      # - name: Upload macOS binary
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: pkg/pkg-macOS-latest-oldrel/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
+      #     asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}_oldrel.tar.gz
+      #     asset_content_type: application/gzip
 
       - name: Upload Windows binary
         uses: actions/upload-release-asset@v1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.7.1
+Version: 0.7.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# mcstate 0.7.2
+
+* Multistage particle filters now cope with running data covering a subset of their stages
+* Drop support for chnging initial step via particle filter initial function for deterministic and nested filters
+
 # mcstate 0.7.1
 
 * New helper function `mcstate::particle_filter_initial` for creating particle filter initial state functions from restart data.

--- a/R/particle_filter_state_nested.R
+++ b/R/particle_filter_state_nested.R
@@ -85,7 +85,7 @@ particle_filter_state_nested <- R6::R6Class(
         model$update_state(pars = pars, step = steps[[1L]])
       }
 
-      steps <- set_nested_model_state(model, initial, pars, n_particles, steps)
+      set_nested_model_state(model, initial, pars, n_particles)
 
       index_data <- if (is.null(index)) NULL else lapply(model$info(), index)
 
@@ -313,60 +313,24 @@ particle_filter_state_nested <- R6::R6Class(
   ))
 
 
-set_nested_model_state <- function(model, initial, pars, n_particles, steps) {
-  if (!is.null(initial)) {
-    initial_data <- Map(initial,
-                        info = model$info(),
-                        pars = pars,
-                        MoreArgs = list(n_particles = n_particles)
-    )
-
-    if (!all(vlapply(initial_data, is.null))) {
-      init_step <- lapply(initial_data, try_list_get, "step")
-      init_step_len <- lengths(init_step)
-      init_state <- lapply(initial_data, try_list_get, "state")
-      init_state_len <- lengths(init_state)
-
-      if (length(unique(init_step_len)) != 1) {
-          stop(sprintf("initial() produced unequal step lengths %s",
-              str_collapse(init_step_len)))
-      }
-      init_step_len <- init_step_len[[1]]
-
-      if (length(unique(init_state_len)) != 1) {
-          stop(sprintf("initial() produced unequal state lengths %s",
-              str_collapse(init_state_len)))
-      }
-      init_state_len <- init_state_len[[1]]
-
-      if (init_step_len > 0 || init_state_len > 0) {
-        if (init_step_len == 0) {
-          init_step <- NULL
-        } else if (init_step_len == 1) {
-          init_step <- rep(unlist(init_step), each = n_particles)
-        } else if (init_step_len == n_particles) {
-          init_step <- unlist(init_step)
-        } else {
-          stop(sprintf("initial() produced unexpected step length %d
-                             (expected 1 or %d)", init_step_len,
-                       n_particles))
-        }
-
-        if (init_state_len > 0) {
-          init_state <- matrix(unlist(init_state), ncol = length(pars))
-        } else {
-          init_state <- NULL
-        }
-
-        steps <- particle_steps(steps, init_step)
-        model$update_state(state = init_state, step = init_step)
-      } else {
-        model$update_state(state = list_to_array(initial_data))
-      }
-    } else {
-      model$update_state(state = NULL)
-    }
+set_nested_model_state <- function(model, initial, pars, n_particles) {
+  if (is.null(initial)) {
+    return()
   }
 
-  steps
+  state <- Map(initial, model$info(), rep(n_particles, length(pars)), pars)
+  if (all(vlapply(state, is.null))) {
+    return()
+  }
+
+  if (any(vlapply(state, is.list))) {
+    stop("Setting 'step' from initial no longer supported")
+  }
+
+  len <- lengths(state)
+  if (length(unique(len)) != 1) {
+    stop(sprintf("initial() produced unequal state lengths %s",
+                 str_collapse(len)))
+  }
+  model$update_state(state = list_to_array(state))
 }

--- a/R/particle_filter_state_nested.R
+++ b/R/particle_filter_state_nested.R
@@ -332,5 +332,11 @@ set_nested_model_state <- function(model, initial, pars, n_particles) {
     stop(sprintf("initial() produced unequal state lengths %s",
                  str_collapse(len)))
   }
-  model$update_state(state = list_to_array(state))
+
+  if (is.null(dim(state[[1]]))) {
+    state_array <- matrix(unlist(state, FALSE, FALSE), ncol = length(pars))
+  } else {
+    state_array <- list_to_array(state)
+  }
+  model$update_state(state = state_array)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -222,10 +222,6 @@ normalise <- function(x) {
   x / sum(x)
 }
 
-try_list_get <- function(list, nm) {
-  tryCatch(list[[nm]], error = function(e) NULL)
-}
-
 
 test_integer <- function(x, name = deparse(substitute(x)),
                          what = "integer") {

--- a/tests/testthat/test-particle-filter-multistage.R
+++ b/tests/testthat/test-particle-filter-multistage.R
@@ -267,27 +267,6 @@ test_that("multistage, dimension changing, model agrees with single stage", {
 })
 
 
-test_that("All times must be found in the data", {
-  dat <- example_sir()
-  index <- function(info) {
-    list(run = 5L, state = c(S = 1, I = 2, R = 3))
-  }
-
-  pars_base <- dat$pars$model(dat$pars$initial())
-  epochs <- list(multistage_epoch(10.5),
-                 multistage_epoch(20),
-                 multistage_epoch(200))
-  filter <- particle_filter$new(dat$data, dat$model, 42, dat$compare,
-                                index = index, seed = 1L)
-  expect_error(
-    filter$run(multistage_parameters(pars_base, epochs[1:2])),
-    "Could not map epoch to filter time: error for 1")
-  expect_error(
-    filter$run(multistage_parameters(pars_base, epochs)),
-    "Could not map epoch to filter time: error for 1, 3")
-})
-
-
 test_that("Require named index for history-saving multistage filter", {
   dat <- example_sir()
   index <- function(info) {

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -135,10 +135,6 @@ test_that("Control the comparison function", {
 
 
 test_that("Control the starting point of the simulation", {
-  initial <- function(info, n_particles, pars) {
-    list(step = pars$initial)
-  }
-
   dat <- example_sir()
 
   ## The usual version:

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -148,11 +148,11 @@ test_that("Control the starting point of the simulation", {
   set.seed(1)
   ll1 <- p1$run()
 
+  ## Tuning the start date
   data_raw <- dat$data_raw
   data_raw$day <- data_raw$day + 100
   data <- particle_filter_data(data_raw, "day", 4, 100)
 
-  ## Tuning the start date
   p2 <- particle_filter$new(data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   set.seed(1)
@@ -903,7 +903,7 @@ test_that("particle filter state nested - errors", {
   set.seed(1)
 
   pars <- list(list(beta = 0.2, gamma = 0.1),
-                               list(beta = 0.3, gamma = 0.1))
+               list(beta = 0.3, gamma = 0.1))
 
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index)
@@ -911,43 +911,21 @@ test_that("particle filter state nested - errors", {
   expect_error(p$run(pars[1]), "the length")
 })
 
-test_that("nested pf with initial", {
+test_that("can't change initial step via initial in nested filter", {
   initial <- function(info, n_particles, pars) {
-    list(step = pars$initial)
+    list(step = 0)
   }
 
   dat <- example_sir_shared()
   n_particles <- 42
-  data <- dat$data
-  offset <- 400
-  data[c("step_start", "step_end")] <-
-    data[c("step_start", "step_end")] + offset
-  data$step_start[c(1, 101)] <- 0
 
   pars <- list(list(beta = 0.2, gamma = 0.1),
-                               list(beta = 0.3, gamma = 0.1))
+               list(beta = 0.3, gamma = 0.1))
 
-  ## The usual version:
-  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
-                            index = dat$index)
-  set.seed(1)
-  ll1 <- p1$run(pars)
-
-  ## Tuning the start date
-  p2 <- particle_filter$new(data, dat$model, n_particles, dat$compare,
-                            index = dat$index, initial = initial)
-  set.seed(1)
-  pars <- list(list(beta = 0.2, gamma = 0.1, initial = as.integer(offset)),
-               list(beta = 0.3, gamma = 0.1, initial = as.integer(offset)))
-  ll2 <- p2$run(pars)
-  expect_identical(ll1, ll2)
-
-  ## Running from the beginning is much worse:
-  set.seed(1)
-  pars <- list(list(beta = 0.2, gamma = 0.1, initial = 0),
-               list(beta = 0.3, gamma = 0.1, initial = 0))
-  ll3 <- p2$run(pars)
-  expect_true(all(ll3 < ll1))
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index, initial = initial)
+  expect_error(p$run(pars),
+               "Setting 'step' from initial no longer supported")
 })
 
 test_that("Can fork a particle_filter_state_nested object", {
@@ -1075,47 +1053,6 @@ test_that("nested particle filter initial not list", {
   expect_is(p$run(pars), "numeric")
 })
 
-test_that("nested particle filter initial - silent length pop", {
-  dat <- example_sir_shared()
-  n_particles <- 42
-  initial <- function(...) list(step = 1)
-  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
-                           index = dat$index, initial = initial, seed = 100)
-  pars <- list(list(beta = 0.2, gamma = 0.1),
-               list(beta = 0.3, gamma = 0.1))
-  expect_silent(p$run(pars))
-
-  dat <- example_sir_shared()
-  n_particles <- 42
-  initial <- function(...) list(step = numeric(42))
-  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
-                           index = dat$index, initial = initial, seed = 100)
-  pars <- list(list(beta = 0.2, gamma = 0.1),
-               list(beta = 0.3, gamma = 0.1))
-  expect_silent(p$run(pars))
-})
-
-test_that("nested particle filter initial - error wrong length", {
-  dat <- example_sir_shared()
-  n_particles <- 42
-  initial <- function(...) list(step = 2:4)
-  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
-                           index = dat$index, initial = initial, seed = 100)
-  pars <- list(list(beta = 0.2, gamma = 0.1),
-               list(beta = 0.3, gamma = 0.1))
-  expect_error(p$run(pars), "length")
-
-  dat <- example_sir_shared()
-  n_particles <- 42
-  initial <- function(info, n_particles, pars) {
-    list(step = pars$initial)
-  }
-  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
-                           index = dat$index, initial = initial, seed = 100)
-  pars <- list(list(beta = 0.2, gamma = 0.1, initial = 0),
-               list(beta = 0.3, gamma = 0.1, initial = 0:1))
-  expect_error(p$run(pars), "unequal step")
-})
 
 test_that("return names on nested history, if present", {
   dat <- example_sir_shared()
@@ -1185,51 +1122,25 @@ test_that("Control the starting point of a nested simulation", {
   dat <- example_sir_shared()
   n_particles <- 42
 
-  data <- dat$data
-  ## Drop extra columns that are confusing in this context
-  data <- data[setdiff(names(data), c("day_start", "day_end"))]
-  ## Offset the data by a considerable margin:
-  offset <- 400
-  data[c("step_start", "step_end")] <-
-    data[c("step_start", "step_end")] + offset
-  ## A burnin step:
-  ## pop a
-  intro_a <- data[data$population == "a", ][1, ]
-  intro_a$incidence <- NA
-  intro_a$step_start <- 0
-  intro_a$step_end <- data$step_start[[1]]
-  ## pop b
-  intro_b <- data[data$population == "b", ][1, ]
-  intro_b$incidence <- NA
-  intro_b$step_start <- 0
-  intro_b$step_end <- data$step_start[[1]]
-  ## Our combination data:
-  data <- rbind(intro_a,
-                data[data$population == "a", ],
-                intro_b,
-                data[data$population == "b", ])
+  pars <- list(list(I0 = 10, beta = 0.2, gamma = 0.1),
+               list(I0 = 10, beta = 0.3, gamma = 0.1))
 
-  pars <- list(list(I0 = 10, beta = 0.2, gamma = 0.1, step = offset),
-               list(I0 = 10, beta = 0.3, gamma = 0.1, step = offset))
-
-  ## The usual version, with normal data:
+  ## The usual version
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index)
   set.seed(1)
   ll1 <- p1$run(pars)
 
-  ## Then tune the start date to get the same effect:
-  initial <- function(info, n_particles, pars) {
-    list(state = c(1000, pars$I0, 0, 0, 0),
-         step = pars$step)
-  }
-
   ## Tuning the start date
+  data_raw <- dat$data_raw
+  data_raw$day <- data_raw$day + 100
+  data <- particle_filter_data(data_raw, time = "day", 4, 100,
+                               population = "populations")
+
   p2 <- particle_filter$new(data, dat$model, n_particles, dat$compare,
-                            index = dat$index, initial = initial)
+                            index = dat$index)
   set.seed(1)
   ll2 <- p2$run(pars)
-
   expect_identical(ll1, ll2)
 })
 
@@ -1241,7 +1152,7 @@ test_that("nested error on unequal state", {
                list(I0 = 10, beta = 0.3, gamma = 0.1))
 
   initial <- function(info, n_particles, pars) {
-    list(state = c(1000, pars$I0, 0, 0, 0))
+    c(1000, pars$I0, 0, 0, 0)
   }
 
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
@@ -1258,7 +1169,7 @@ test_that("nested silent on initial w. state w/o step", {
                list(beta = 0.3, gamma = 0.1))
 
   initial <- function(info, n_particles, pars) {
-    list(state = c(1000, 0, 0, 0, 0))
+    c(1000, 0, 0, 0, 0)
   }
 
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,


### PR DESCRIPTION
This PR does some awkward bookkeeping on top of the previous one to allow multistage fits to restart gracefully where some epochs will be unused.  This required the removal of `initial(pars)` returning the first step after 0.7.1 we can read that directly from the data. Then it's just a case of finding stages that will be ignored and dropping them, at which point the filter proceeds as before (even if that means running just a single stage).

I've also cleared out support for initial control of step from the deterministic and nested filters as these were left in last time.  The nested one in particular clears out a lot of complex code

I've *also* disabled the macos oldrel release as that is failing due to configuration issues (as seen previously on sircovid)