### PR TITLE
Support for initial log likelihoods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.8.1
+
+* New argument to `mcstate::particle_filter` and `mcstate::particle_deterministic`, `initial_log_likelihood` which can be used to compute the probabilities of non-time series data (#185)
+
 # mcstate 0.8.0
 
 * Rework the "nested" support; this now returns output in a different dimension order.  Primarily this is an internal refactoring.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mcstate 0.8.1
 
-* New argument to `mcstate::particle_filter` and `mcstate::particle_deterministic`, `initial_log_likelihood` which can be used to compute the probabilities of non-time series data (#185)
+* New argument to `mcstate::particle_filter` and `mcstate::particle_deterministic`, `constant_log_likelihood` which can be used to compute the probabilities of non-time series data (#185)
 
 # mcstate 0.8.0
 

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -104,7 +104,9 @@ particle_deterministic <- R6::R6Class(
     initialize = function(data, model, compare,
                           index = NULL, initial = NULL,
                           initial_log_likelihood = NULL, n_threads = 1L) {
-      assert_is(model, "dust_generator")
+      if (!is_dust_generator(model)) {
+        stop("'model' must be a dust_generator")
+      }
       assert_function_or_null(index)
       assert_function_or_null(initial)
       assert_function_or_null(initial_log_likelihood)

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -18,6 +18,7 @@ particle_deterministic <- R6::R6Class(
     initial = NULL,
     index = NULL,
     compare = NULL,
+    initial_log_likelihood = NULL,
     last_model = NULL,
     last_history = NULL,
     last_state = NULL,
@@ -89,6 +90,12 @@ particle_deterministic <- R6::R6Class(
     ##' the starting step, which is equivalent to returning
     ##' `list(state = state, step = NULL)`.
     ##'
+    ##' @param initial_log_likelihood An optional function, taking the
+    ##' model parameters, that computes the initial log-likelihood value.
+    ##' You can use this where your likelihood depends both on the time
+    ##' series (via `data`) but also on some non-temporal data.  You
+    ##' should bind any non-parameter dependencies into this closure.
+    ##'
     ##' @param n_threads Number of threads to use when running the
     ##' simulation. Defaults to 1, and should not be set higher than the
     ##' number of cores available to the machine. This currently has no
@@ -96,16 +103,11 @@ particle_deterministic <- R6::R6Class(
     ##' particle for now.
     initialize = function(data, model, compare,
                           index = NULL, initial = NULL,
-                          n_threads = 1L) {
-      if (!is_dust_generator(model)) {
-        stop("'model' must be a dust_generator")
-      }
-      if (!is.null(index) && !is.function(index)) {
-        stop("'index' must be function if not NULL")
-      }
-      if (!is.null(initial) && !is.function(initial)) {
-        stop("'initial' must be function if not NULL")
-      }
+                          initial_log_likelihood = NULL, n_threads = 1L) {
+      assert_is(model, "dust_generator")
+      assert_function_or_null(index)
+      assert_function_or_null(initial)
+      assert_function_or_null(initial_log_likelihood)
       assert_is(data, "particle_filter_data")
 
       ## NOTE: unlike the particle filter, there is no support for
@@ -126,6 +128,7 @@ particle_deterministic <- R6::R6Class(
       private$compare <- compare
       private$index <- index
       private$initial <- initial
+      private$initial_log_likelihood <- initial_log_likelihood
 
       private$n_threads <- n_threads
 
@@ -205,6 +208,7 @@ particle_deterministic <- R6::R6Class(
         pars, self$model, private$last_model, private$data,
         private$data_split, private$steps, private$n_threads,
         private$initial, private$index, private$compare,
+        private$initial_log_likelihood,
         save_history, save_restart)
     },
 
@@ -295,6 +299,7 @@ particle_deterministic <- R6::R6Class(
            index = private$index,
            initial = private$initial,
            compare = private$compare,
+           initial_log_likelihood = private$initial_log_likelihood,
            n_threads = private$n_threads,
            seed = filter_current_seed(private$last_model, NULL))
     },

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -18,7 +18,7 @@ particle_deterministic <- R6::R6Class(
     initial = NULL,
     index = NULL,
     compare = NULL,
-    initial_log_likelihood = NULL,
+    constant_log_likelihood = NULL,
     last_model = NULL,
     last_history = NULL,
     last_state = NULL,
@@ -90,11 +90,15 @@ particle_deterministic <- R6::R6Class(
     ##' the starting step, which is equivalent to returning
     ##' `list(state = state, step = NULL)`.
     ##'
-    ##' @param initial_log_likelihood An optional function, taking the
-    ##' model parameters, that computes the initial log-likelihood value.
-    ##' You can use this where your likelihood depends both on the time
-    ##' series (via `data`) but also on some non-temporal data.  You
-    ##' should bind any non-parameter dependencies into this closure.
+    ##' @param constant_log_likelihood An optional function, taking the
+    ##' model parameters, that computes the constant part of the
+    ##' log-likelihood value (if any).  You can use this where your
+    ##' likelihood depends both on the time series (via `data`) but also
+    ##' on some non-temporal data.  You should bind any non-parameter
+    ##' dependencies into this closure.  This is applied at the
+    ##' beginning of the filter run, so represents the initial
+    ##' condition of the marginal log likelihood value propagated by
+    ##' the process.
     ##'
     ##' @param n_threads Number of threads to use when running the
     ##' simulation. Defaults to 1, and should not be set higher than the
@@ -103,13 +107,13 @@ particle_deterministic <- R6::R6Class(
     ##' particle for now.
     initialize = function(data, model, compare,
                           index = NULL, initial = NULL,
-                          initial_log_likelihood = NULL, n_threads = 1L) {
+                          constant_log_likelihood = NULL, n_threads = 1L) {
       if (!is_dust_generator(model)) {
         stop("'model' must be a dust_generator")
       }
       assert_function_or_null(index)
       assert_function_or_null(initial)
-      assert_function_or_null(initial_log_likelihood)
+      assert_function_or_null(constant_log_likelihood)
       assert_is(data, "particle_filter_data")
 
       ## NOTE: unlike the particle filter, there is no support for
@@ -130,7 +134,7 @@ particle_deterministic <- R6::R6Class(
       private$compare <- compare
       private$index <- index
       private$initial <- initial
-      private$initial_log_likelihood <- initial_log_likelihood
+      private$constant_log_likelihood <- constant_log_likelihood
 
       private$n_threads <- n_threads
 
@@ -210,7 +214,7 @@ particle_deterministic <- R6::R6Class(
         pars, self$model, private$last_model, private$data,
         private$data_split, private$steps, private$n_threads,
         private$initial, private$index, private$compare,
-        private$initial_log_likelihood,
+        private$constant_log_likelihood,
         save_history, save_restart)
     },
 
@@ -301,7 +305,7 @@ particle_deterministic <- R6::R6Class(
            index = private$index,
            initial = private$initial,
            compare = private$compare,
-           initial_log_likelihood = private$initial_log_likelihood,
+           constant_log_likelihood = private$constant_log_likelihood,
            n_threads = private$n_threads,
            seed = filter_current_seed(private$last_model, NULL))
     },

--- a/R/deterministic_state.R
+++ b/R/deterministic_state.R
@@ -69,10 +69,12 @@ particle_deterministic_state <- R6::R6Class(
     ##' @param initial Initial condition function (or `NULL`)
     ##' @param index Index function (or `NULL`)
     ##' @param compare Compare function
+    ##' @param initial_log_likelihood Initial log likelihood function
     ##' @param save_history Logical, indicating if we should save history
     ##' @param save_restart Vector of steps to save restart at
     initialize = function(pars, generator, model, data, data_split, steps,
                           n_threads, initial, index, compare,
+                          initial_log_likelihood,
                           save_history, save_restart) {
       pars_multi <- inherits(data, "particle_filter_data_nested")
       support <- particle_deterministic_state_support(pars_multi)
@@ -144,7 +146,8 @@ particle_deterministic_state <- R6::R6Class(
 
       ## Variable (see also history)
       self$model <- model
-      self$log_likelihood <- rep(0, prod(shape[-1]))
+      self$log_likelihood <- particle_filter_initial_log_likelihood(
+        pars, pars_multi, initial_log_likelihood)
     },
 
     ##' @description Run the deterministic particle to the end of the data.
@@ -249,6 +252,7 @@ particle_deterministic_state <- R6::R6Class(
       model <- NULL
       save_history <- !is.null(self$history)
       initial <- NULL
+      initial_log_likelihood <- NULL
 
       if (is.null(pars)) {
         pars <- self$model$pars()
@@ -256,7 +260,8 @@ particle_deterministic_state <- R6::R6Class(
       ret <- particle_deterministic_state$new(
         pars, private$generator, model, private$data, private$data_split,
         private$steps, private$n_threads, initial, private$index,
-        private$compare, save_history, private$save_restart)
+        private$compare, initial_log_likelihood,
+        save_history, private$save_restart)
 
       particle_filter_update_state(transform_state, self$model, ret$model)
 

--- a/R/deterministic_state.R
+++ b/R/deterministic_state.R
@@ -69,12 +69,12 @@ particle_deterministic_state <- R6::R6Class(
     ##' @param initial Initial condition function (or `NULL`)
     ##' @param index Index function (or `NULL`)
     ##' @param compare Compare function
-    ##' @param initial_log_likelihood Initial log likelihood function
+    ##' @param constant_log_likelihood Constant log likelihood function
     ##' @param save_history Logical, indicating if we should save history
     ##' @param save_restart Vector of steps to save restart at
     initialize = function(pars, generator, model, data, data_split, steps,
                           n_threads, initial, index, compare,
-                          initial_log_likelihood,
+                          constant_log_likelihood,
                           save_history, save_restart) {
       pars_multi <- inherits(data, "particle_filter_data_nested")
       support <- particle_deterministic_state_support(pars_multi)
@@ -146,8 +146,8 @@ particle_deterministic_state <- R6::R6Class(
 
       ## Variable (see also history)
       self$model <- model
-      self$log_likelihood <- particle_filter_initial_log_likelihood(
-        pars, pars_multi, initial_log_likelihood)
+      self$log_likelihood <- particle_filter_constant_log_likelihood(
+        pars, pars_multi, constant_log_likelihood)
     },
 
     ##' @description Run the deterministic particle to the end of the data.
@@ -252,7 +252,7 @@ particle_deterministic_state <- R6::R6Class(
       model <- NULL
       save_history <- !is.null(self$history)
       initial <- NULL
-      initial_log_likelihood <- NULL
+      constant_log_likelihood <- NULL
 
       if (is.null(pars)) {
         pars <- self$model$pars()
@@ -260,7 +260,7 @@ particle_deterministic_state <- R6::R6Class(
       ret <- particle_deterministic_state$new(
         pars, private$generator, model, private$data, private$data_split,
         private$steps, private$n_threads, initial, private$index,
-        private$compare, initial_log_likelihood,
+        private$compare, constant_log_likelihood,
         save_history, private$save_restart)
 
       particle_filter_update_state(transform_state, self$model, ret$model)

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -70,7 +70,7 @@ particle_filter <- R6::R6Class(
     index = NULL,
     initial = NULL,
     compare = NULL,
-    initial_log_likelihood = NULL,
+    constant_log_likelihood = NULL,
     gpu_config = NULL,
     ## Control for dust
     seed = NULL,
@@ -155,11 +155,15 @@ particle_filter <- R6::R6Class(
     ##' the starting step, which is equivalent to returning
     ##' `list(state = state, step = NULL)`.
     ##'
-    ##' @param initial_log_likelihood An optional function, taking the
-    ##' model parameters, that computes the initial log-likelihood value.
-    ##' You can use this where your likelihood depends both on the time
-    ##' series (via `data`) but also on some non-temporal data.  You
-    ##' should bind any non-parameter dependencies into this closure.
+    ##' @param constant_log_likelihood An optional function, taking the
+    ##' model parameters, that computes the constant part of the
+    ##' log-likelihood value (if any).  You can use this where your
+    ##' likelihood depends both on the time series (via `data`) but also
+    ##' on some non-temporal data.  You should bind any non-parameter
+    ##' dependencies into this closure.  This is applied at the
+    ##' beginning of the filter run, so represents the initial
+    ##' condition of the marginal log likelihood value propagated by
+    ##' the filter.
     ##'
     ##' @param n_threads Number of threads to use when running the
     ##' simulation. Defaults to 1, and should not be set higher than the
@@ -184,7 +188,7 @@ particle_filter <- R6::R6Class(
     ##' list will be added in a future version!
     initialize = function(data, model, n_particles, compare,
                           index = NULL, initial = NULL,
-                          initial_log_likelihood = NULL,
+                          constant_log_likelihood = NULL,
                           n_threads = 1L, seed = NULL,
                           gpu_config = NULL) {
       if (!is_dust_generator(model)) {
@@ -192,7 +196,7 @@ particle_filter <- R6::R6Class(
       }
       assert_function_or_null(index)
       assert_function_or_null(initial)
-      assert_function_or_null(initial_log_likelihood)
+      assert_function_or_null(constant_log_likelihood)
       assert_is(data, "particle_filter_data")
 
       if (is.null(compare)) {
@@ -222,7 +226,7 @@ particle_filter <- R6::R6Class(
       private$gpu_config <- gpu_config
       private$index <- index
       private$initial <- initial
-      private$initial_log_likelihood <- initial_log_likelihood
+      private$constant_log_likelihood <- constant_log_likelihood
 
       self$n_particles <- assert_scalar_positive_integer(n_particles)
       private$n_threads <- assert_scalar_positive_integer(n_threads)
@@ -315,7 +319,7 @@ particle_filter <- R6::R6Class(
         pars, self$model, private$last_model, private$data,
         private$data_split, private$steps, self$n_particles,
         private$n_threads, private$initial, private$index, private$compare,
-        private$initial_log_likelihood, private$gpu_config, private$seed,
+        private$constant_log_likelihood, private$gpu_config, private$seed,
         min_log_likelihood, save_history, save_restart)
     },
 
@@ -425,7 +429,7 @@ particle_filter <- R6::R6Class(
            index = private$index,
            initial = private$initial,
            compare = private$compare,
-           initial_log_likelihood = private$initial_log_likelihood,
+           constant_log_likelihood = private$constant_log_likelihood,
            gpu_config = private$gpu_config,
            n_threads = private$n_threads,
            seed = filter_current_seed(private$last_model, private$seed))
@@ -474,7 +478,7 @@ particle_filter_from_inputs <- function(inputs, seed = NULL) {
       compare = inputs$compare,
       index = inputs$index,
       initial = inputs$initial,
-      initial_log_likelihood = inputs$initial_log_likelihood,
+      constant_log_likelihood = inputs$constant_log_likelihood,
       n_threads = inputs$n_threads)
   } else {
     particle_filter$new(
@@ -485,7 +489,7 @@ particle_filter_from_inputs <- function(inputs, seed = NULL) {
       gpu_config = inputs$gpu_config,
       index = inputs$index,
       initial = inputs$initial,
-      initial_log_likelihood = inputs$initial_log_likelihood,
+      constant_log_likelihood = inputs$constant_log_likelihood,
       n_threads = inputs$n_threads,
       seed = seed %||% inputs$seed)
   }

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -70,6 +70,7 @@ particle_filter <- R6::R6Class(
     index = NULL,
     initial = NULL,
     compare = NULL,
+    initial_log_likelihood = NULL,
     gpu_config = NULL,
     ## Control for dust
     seed = NULL,
@@ -154,6 +155,12 @@ particle_filter <- R6::R6Class(
     ##' the starting step, which is equivalent to returning
     ##' `list(state = state, step = NULL)`.
     ##'
+    ##' @param initial_log_likelihood An optional function, taking the
+    ##' model parameters, that computes the initial log-likelihood value.
+    ##' You can use this where your likelihood depends both on the time
+    ##' series (via `data`) but also on some non-temporal data.  You
+    ##' should bind any non-parameter dependencies into this closure.
+    ##'
     ##' @param n_threads Number of threads to use when running the
     ##' simulation. Defaults to 1, and should not be set higher than the
     ##' number of cores available to the machine.
@@ -177,17 +184,13 @@ particle_filter <- R6::R6Class(
     ##' list will be added in a future version!
     initialize = function(data, model, n_particles, compare,
                           index = NULL, initial = NULL,
+                          initial_log_likelihood = NULL,
                           n_threads = 1L, seed = NULL,
                           gpu_config = NULL) {
-      if (!is_dust_generator(model)) {
-        stop("'model' must be a dust_generator")
-      }
-      if (!is.null(index) && !is.function(index)) {
-        stop("'index' must be function if not NULL")
-      }
-      if (!is.null(initial) && !is.function(initial)) {
-        stop("'initial' must be function if not NULL")
-      }
+      assert_is(model, "dust_generator")
+      assert_function_or_null(index)
+      assert_function_or_null(initial)
+      assert_function_or_null(initial_log_likelihood)
       assert_is(data, "particle_filter_data")
 
       if (is.null(compare)) {
@@ -217,6 +220,7 @@ particle_filter <- R6::R6Class(
       private$gpu_config <- gpu_config
       private$index <- index
       private$initial <- initial
+      private$initial_log_likelihood <- initial_log_likelihood
 
       self$n_particles <- assert_scalar_positive_integer(n_particles)
       private$n_threads <- assert_scalar_positive_integer(n_threads)
@@ -309,8 +313,8 @@ particle_filter <- R6::R6Class(
         pars, self$model, private$last_model, private$data,
         private$data_split, private$steps, self$n_particles,
         private$n_threads, private$initial, private$index, private$compare,
-        private$gpu_config, private$seed, min_log_likelihood,
-        save_history, save_restart)
+        private$initial_log_likelihood, private$gpu_config, private$seed,
+        min_log_likelihood, save_history, save_restart)
     },
 
     ##' @description Extract the current model state, optionally filtering.
@@ -419,6 +423,7 @@ particle_filter <- R6::R6Class(
            index = private$index,
            initial = private$initial,
            compare = private$compare,
+           initial_log_likelihood = private$initial_log_likelihood,
            gpu_config = private$gpu_config,
            n_threads = private$n_threads,
            seed = filter_current_seed(private$last_model, private$seed))
@@ -461,22 +466,26 @@ particle_resample <- function(weights) {
 ## `$inputs()` data, but possibly changing the seed
 particle_filter_from_inputs <- function(inputs, seed = NULL) {
   if (is.null(inputs$n_particles)) {
-    particle_deterministic$new(data = inputs$data,
-                               model = inputs$model,
-                               compare = inputs$compare,
-                               index = inputs$index,
-                               initial = inputs$initial,
-                               n_threads = inputs$n_threads)
+    particle_deterministic$new(
+      data = inputs$data,
+      model = inputs$model,
+      compare = inputs$compare,
+      index = inputs$index,
+      initial = inputs$initial,
+      initial_log_likelihood = inputs$initial_log_likelihood,
+      n_threads = inputs$n_threads)
   } else {
-    particle_filter$new(data = inputs$data,
-                        model = inputs$model,
-                        n_particles = inputs$n_particles,
-                        compare = inputs$compare,
-                        gpu_config = inputs$gpu_config,
-                        index = inputs$index,
-                        initial = inputs$initial,
-                        n_threads = inputs$n_threads,
-                        seed = seed %||% inputs$seed)
+    particle_filter$new(
+      data = inputs$data,
+      model = inputs$model,
+      n_particles = inputs$n_particles,
+      compare = inputs$compare,
+      gpu_config = inputs$gpu_config,
+      index = inputs$index,
+      initial = inputs$initial,
+      initial_log_likelihood = inputs$initial_log_likelihood,
+      n_threads = inputs$n_threads,
+      seed = seed %||% inputs$seed)
   }
 }
 

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -187,7 +187,9 @@ particle_filter <- R6::R6Class(
                           initial_log_likelihood = NULL,
                           n_threads = 1L, seed = NULL,
                           gpu_config = NULL) {
-      assert_is(model, "dust_generator")
+      if (!is_dust_generator(model)) {
+        stop("'model' must be a dust_generator")
+      }
       assert_function_or_null(index)
       assert_function_or_null(initial)
       assert_function_or_null(initial_log_likelihood)

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -45,7 +45,7 @@ particle_filter_state <- R6::R6Class(
       res <- model$filter(save_history, private$save_restart_step)
 
       self$log_likelihood_step <- NA_real_
-      self$log_likelihood <- res$log_likelihood
+      self$log_likelihood <- self$log_likelihood + res$log_likelihood
       self$current_step_index <- nrow(private$steps)
       if (save_history) {
         self$history <- list(value = res$trajectories,
@@ -97,6 +97,7 @@ particle_filter_state <- R6::R6Class(
     ##' @param initial Initial condition function (or `NULL`)
     ##' @param index Index function (or `NULL`)
     ##' @param compare Compare function
+    ##' @param initial_log_likelihood Initial log likelihood function
     ##' @param gpu_config GPU configuration, passed to `generator`
     ##' @param seed Initial RNG seed
     ##' @param min_log_likelihood Early termination control
@@ -104,8 +105,8 @@ particle_filter_state <- R6::R6Class(
     ##' @param save_restart Vector of steps to save restart at
     initialize = function(pars, generator, model, data, data_split, steps,
                           n_particles, n_threads, initial, index, compare,
-                          gpu_config, seed, min_log_likelihood,
-                          save_history, save_restart) {
+                          initial_log_likelihood, gpu_config, seed,
+                          min_log_likelihood, save_history, save_restart) {
       pars_multi <- inherits(data, "particle_filter_data_nested")
       support <- particle_filter_state_support(pars_multi)
 
@@ -180,7 +181,8 @@ particle_filter_state <- R6::R6Class(
 
       ## Variable (see also history)
       self$model <- model
-      self$log_likelihood <- rep(0, prod(shape[-1]))
+      self$log_likelihood <- particle_filter_initial_log_likelihood(
+        pars, pars_multi, initial_log_likelihood)
     },
 
     ##' @description Run the particle filter to the end of the data. This is
@@ -337,6 +339,7 @@ particle_filter_state <- R6::R6Class(
       seed <- self$model$rng_state()
       save_history <- !is.null(self$history)
       initial <- NULL
+      initial_log_likelihood <- NULL
 
       if (is.null(pars)) {
         pars <- self$model$pars()
@@ -344,8 +347,9 @@ particle_filter_state <- R6::R6Class(
       ret <- particle_filter_state$new(
         pars, private$generator, model, private$data, private$data_split,
         private$steps, private$n_particles, private$n_threads,
-        initial, private$index, private$compare, gpu_config,
-        seed, private$min_log_likelihood, save_history, private$save_restart)
+        initial, private$index, private$compare, initial_log_likelihood,
+        gpu_config, seed, private$min_log_likelihood,
+        save_history, private$save_restart)
 
       particle_filter_update_state(transform_state, self$model, ret$model)
 
@@ -377,7 +381,8 @@ particle_filter_state <- R6::R6Class(
       ret <- particle_filter_state$new(
         pars, private$generator, model, private$data, private$data_split,
         private$steps, private$n_particles, private$n_threads,
-        private$initial, private$index, private$compare, gpu_config,
+        private$initial, private$index, private$compare,
+        private$initial_log_likelihood, gpu_config,
         seed, private$min_log_likelihood, save_history, private$save_restart)
 
       ## Run it up to the same point
@@ -436,6 +441,24 @@ particle_filter_early_exit <- function(log_likelihood, min_log_likelihood) {
     sum(log_likelihood) < min_log_likelihood
   } else {
     all(log_likelihood < min_log_likelihood)
+  }
+}
+
+
+particle_filter_initial_log_likelihood <- function(pars, pars_multi,
+                                                   initial_log_likelihood) {
+  if (is.null(initial_log_likelihood)) {
+    if (pars_multi) {
+      rep(0, length(pars))
+    } else {
+      0
+    }
+  } else {
+    if (pars_multi) {
+      vnapply(pars, initial_log_likelihood)
+    } else {
+      initial_log_likelihood(pars)
+    }
   }
 }
 

--- a/R/smc2.R
+++ b/R/smc2.R
@@ -65,9 +65,6 @@ smc2_engine <- R6::R6Class(
       log_likelihood <- rep(0.0, control$n_parameter_sets)
 
       inputs <- filter$inputs()
-      ## TODO: fix this in dust to make it easier to get a
-      ## "reasonable" state. We might also advance the state with a
-      ## long jump first?
       seed <- dust::dust_rng_distributed_state(inputs$seed,
                                                inputs$n_particles,
                                                control$n_parameter_sets,
@@ -75,9 +72,8 @@ smc2_engine <- R6::R6Class(
       filters <- vector("list", control$n_parameter_sets)
       pars_model <- pars$model(theta)
       for (i in seq_len(control$n_parameter_sets)) {
-        f <- particle_filter$new(
-          inputs$data, inputs$model, inputs$n_particles, inputs$compare,
-          inputs$index, inputs$initial, inputs$n_threads, seed[[i]])
+        inputs$seed <- seed[[i]]
+        f <- particle_filter_from_inputs(inputs)
         filters[[i]] <- f$run_begin(pars_model[[i]], control$save_trajectories)
       }
 

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -16,6 +16,14 @@ assert_function <- function(x, name = deparse(substitute(x))) {
 }
 
 
+assert_function_or_null <- function(x, name = deparse(substitute(x))) {
+  if (!is.null(x) && !is.function(x)) {
+    stop(sprintf("'%s' must be function if not NULL", name), call. = FALSE)
+  }
+  invisible(x)
+}
+
+
 assert_named <- function(x, unique = FALSE, name = deparse(substitute(x))) {
   if (is.null(names(x))) {
     stop(sprintf("'%s' must be named", name), call. = FALSE)

--- a/man/particle_deterministic.Rd
+++ b/man/particle_deterministic.Rd
@@ -47,7 +47,7 @@ Create the particle filter
   compare,
   index = NULL,
   initial = NULL,
-  initial_log_likelihood = NULL,
+  constant_log_likelihood = NULL,
   n_threads = 1L
 )}\if{html}{\out{</div>}}
 }
@@ -106,11 +106,15 @@ can also return a vector or matrix of \code{state} and not alter
 the starting step, which is equivalent to returning
 \code{list(state = state, step = NULL)}.}
 
-\item{\code{initial_log_likelihood}}{An optional function, taking the
-model parameters, that computes the initial log-likelihood value.
-You can use this where your likelihood depends both on the time
-series (via \code{data}) but also on some non-temporal data.  You
-should bind any non-parameter dependencies into this closure.}
+\item{\code{constant_log_likelihood}}{An optional function, taking the
+model parameters, that computes the constant part of the
+log-likelihood value (if any).  You can use this where your
+likelihood depends both on the time series (via \code{data}) but also
+on some non-temporal data.  You should bind any non-parameter
+dependencies into this closure.  This is applied at the
+beginning of the filter run, so represents the initial
+condition of the marginal log likelihood value propagated by
+the process.}
 
 \item{\code{n_threads}}{Number of threads to use when running the
 simulation. Defaults to 1, and should not be set higher than the

--- a/man/particle_deterministic.Rd
+++ b/man/particle_deterministic.Rd
@@ -47,6 +47,7 @@ Create the particle filter
   compare,
   index = NULL,
   initial = NULL,
+  initial_log_likelihood = NULL,
   n_threads = 1L
 )}\if{html}{\out{</div>}}
 }
@@ -104,6 +105,12 @@ constructor, i.e., not less than the first element of
 can also return a vector or matrix of \code{state} and not alter
 the starting step, which is equivalent to returning
 \code{list(state = state, step = NULL)}.}
+
+\item{\code{initial_log_likelihood}}{An optional function, taking the
+model parameters, that computes the initial log-likelihood value.
+You can use this where your likelihood depends both on the time
+series (via \code{data}) but also on some non-temporal data.  You
+should bind any non-parameter dependencies into this closure.}
 
 \item{\code{n_threads}}{Number of threads to use when running the
 simulation. Defaults to 1, and should not be set higher than the

--- a/man/particle_deterministic_state.Rd
+++ b/man/particle_deterministic_state.Rd
@@ -61,7 +61,7 @@ documented.
   initial,
   index,
   compare,
-  initial_log_likelihood,
+  constant_log_likelihood,
   save_history,
   save_restart
 )}\if{html}{\out{</div>}}
@@ -90,7 +90,7 @@ documented.
 
 \item{\code{compare}}{Compare function}
 
-\item{\code{initial_log_likelihood}}{Initial log likelihood function}
+\item{\code{constant_log_likelihood}}{Constant log likelihood function}
 
 \item{\code{save_history}}{Logical, indicating if we should save history}
 

--- a/man/particle_deterministic_state.Rd
+++ b/man/particle_deterministic_state.Rd
@@ -61,6 +61,7 @@ documented.
   initial,
   index,
   compare,
+  initial_log_likelihood,
   save_history,
   save_restart
 )}\if{html}{\out{</div>}}
@@ -88,6 +89,8 @@ documented.
 \item{\code{index}}{Index function (or \code{NULL})}
 
 \item{\code{compare}}{Compare function}
+
+\item{\code{initial_log_likelihood}}{Initial log likelihood function}
 
 \item{\code{save_history}}{Logical, indicating if we should save history}
 

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -102,7 +102,7 @@ Create the particle filter
   compare,
   index = NULL,
   initial = NULL,
-  initial_log_likelihood = NULL,
+  constant_log_likelihood = NULL,
   n_threads = 1L,
   seed = NULL,
   gpu_config = NULL
@@ -168,11 +168,15 @@ can also return a vector or matrix of \code{state} and not alter
 the starting step, which is equivalent to returning
 \code{list(state = state, step = NULL)}.}
 
-\item{\code{initial_log_likelihood}}{An optional function, taking the
-model parameters, that computes the initial log-likelihood value.
-You can use this where your likelihood depends both on the time
-series (via \code{data}) but also on some non-temporal data.  You
-should bind any non-parameter dependencies into this closure.}
+\item{\code{constant_log_likelihood}}{An optional function, taking the
+model parameters, that computes the constant part of the
+log-likelihood value (if any).  You can use this where your
+likelihood depends both on the time series (via \code{data}) but also
+on some non-temporal data.  You should bind any non-parameter
+dependencies into this closure.  This is applied at the
+beginning of the filter run, so represents the initial
+condition of the marginal log likelihood value propagated by
+the filter.}
 
 \item{\code{n_threads}}{Number of threads to use when running the
 simulation. Defaults to 1, and should not be set higher than the

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -102,6 +102,7 @@ Create the particle filter
   compare,
   index = NULL,
   initial = NULL,
+  initial_log_likelihood = NULL,
   n_threads = 1L,
   seed = NULL,
   gpu_config = NULL
@@ -166,6 +167,12 @@ constructor, i.e., not less than the first element of
 can also return a vector or matrix of \code{state} and not alter
 the starting step, which is equivalent to returning
 \code{list(state = state, step = NULL)}.}
+
+\item{\code{initial_log_likelihood}}{An optional function, taking the
+model parameters, that computes the initial log-likelihood value.
+You can use this where your likelihood depends both on the time
+series (via \code{data}) but also on some non-temporal data.  You
+should bind any non-parameter dependencies into this closure.}
 
 \item{\code{n_threads}}{Number of threads to use when running the
 simulation. Defaults to 1, and should not be set higher than the

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -69,6 +69,7 @@ documented.
   initial,
   index,
   compare,
+  initial_log_likelihood,
   gpu_config,
   seed,
   min_log_likelihood,
@@ -101,6 +102,8 @@ documented.
 \item{\code{index}}{Index function (or \code{NULL})}
 
 \item{\code{compare}}{Compare function}
+
+\item{\code{initial_log_likelihood}}{Initial log likelihood function}
 
 \item{\code{gpu_config}}{GPU configuration, passed to \code{generator}}
 

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -69,7 +69,7 @@ documented.
   initial,
   index,
   compare,
-  initial_log_likelihood,
+  constant_log_likelihood,
   gpu_config,
   seed,
   min_log_likelihood,
@@ -103,7 +103,7 @@ documented.
 
 \item{\code{compare}}{Compare function}
 
-\item{\code{initial_log_likelihood}}{Initial log likelihood function}
+\item{\code{constant_log_likelihood}}{Constant log likelihood function}
 
 \item{\code{gpu_config}}{GPU configuration, passed to \code{generator}}
 

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -344,7 +344,7 @@ test_that("Can offset the initial likelihood", {
   dat <- example_sir()
   n_particles <- 42
 
-  initial_ll <- function(pars) {
+  constant_ll <- function(pars) {
     10
   }
 
@@ -355,7 +355,7 @@ test_that("Can offset the initial likelihood", {
 
   set.seed(1)
   p2 <- particle_deterministic$new(dat$data, dat$model, dat$compare,
-                            initial_log_likelihood = initial_ll,
+                            constant_log_likelihood = constant_ll,
                             index = dat$index)
   ll2 <- p2$run(save_history = TRUE)
   expect_equal(ll2, ll1 + 10)

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -338,3 +338,27 @@ test_that("Can partially run a deterministic particle and resume", {
   expect_equal(ll3_2, ll1, tolerance = 1e-11)
   expect_equal(s3$history$value, p1$history(), tolerance = 1e-11)
 })
+
+
+test_that("Can offset the initial likelihood", {
+  dat <- example_sir()
+  n_particles <- 42
+
+  initial_ll <- function(pars) {
+    10
+  }
+
+  set.seed(1)
+  p1 <- particle_deterministic$new(dat$data, dat$model, dat$compare,
+                                   index = dat$index)
+  ll1 <- p1$run(save_history = TRUE)
+
+  set.seed(1)
+  p2 <- particle_deterministic$new(dat$data, dat$model, dat$compare,
+                            initial_log_likelihood = initial_ll,
+                            index = dat$index)
+  ll2 <- p2$run(save_history = TRUE)
+  expect_equal(ll2, ll1 + 10)
+  expect_identical(p1$history(), p2$history())
+  expect_identical(p1$state(), p2$state())
+})

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1370,3 +1370,28 @@ test_that("Can offset the initial likelihood", {
   expect_identical(p1$history(), p2$history())
   expect_identical(p1$state(), p2$state())
 })
+
+
+test_that("can save history - nested", {
+  dat <- example_sir_shared()
+  n_particles <- 42
+  set.seed(1)
+
+  pars <- list(list(beta = 0.2, gamma = 0.1),
+               list(beta = 0.3, gamma = 0.2))
+  initial_log_likelihood <- function(p) {
+    -p$beta * 10 - p$gamma
+  }
+
+  set.seed(1)
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index, seed = 1)
+  ll1 <- p1$run(pars)
+
+  set.seed(1)
+  p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            index = dat$index, seed = 1,
+                            initial_log_likelihood = initial_log_likelihood)
+  ll2 <- p2$run(pars)
+  expect_equal(ll2, ll1 - c(2.1, 3.2))
+})

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1352,7 +1352,7 @@ test_that("Can offset the initial likelihood", {
   dat <- example_sir()
   n_particles <- 42
 
-  initial_ll <- function(pars) {
+  constant_ll <- function(pars) {
     10
   }
 
@@ -1363,7 +1363,7 @@ test_that("Can offset the initial likelihood", {
 
   set.seed(1)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
-                            initial_log_likelihood = initial_ll,
+                            constant_log_likelihood = constant_ll,
                             index = dat$index, seed = 1L)
   ll2 <- p2$run(save_history = TRUE)
   expect_equal(ll2, ll1 + 10)
@@ -1379,7 +1379,7 @@ test_that("can save history - nested", {
 
   pars <- list(list(beta = 0.2, gamma = 0.1),
                list(beta = 0.3, gamma = 0.2))
-  initial_log_likelihood <- function(p) {
+  constant_log_likelihood <- function(p) {
     -p$beta * 10 - p$gamma
   }
 
@@ -1391,7 +1391,7 @@ test_that("can save history - nested", {
   set.seed(1)
   p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                             index = dat$index, seed = 1,
-                            initial_log_likelihood = initial_log_likelihood)
+                            constant_log_likelihood = constant_log_likelihood)
   ll2 <- p2$run(pars)
   expect_equal(ll2, ll1 - c(2.1, 3.2))
 })

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1346,3 +1346,27 @@ test_that("Confirm nested filter is correct", {
   expect_identical(s3$history$order[, 2, ], s2$history$order)
   expect_identical(s3$history$index, s1$history$index)
 })
+
+
+test_that("Can offset the initial likelihood", {
+  dat <- example_sir()
+  n_particles <- 42
+
+  initial_ll <- function(pars) {
+    10
+  }
+
+  set.seed(1)
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index, seed = 1L)
+  ll1 <- p1$run(save_history = TRUE)
+
+  set.seed(1)
+  p2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                            initial_log_likelihood = initial_ll,
+                            index = dat$index, seed = 1L)
+  ll2 <- p2$run(save_history = TRUE)
+  expect_equal(ll2, ll1 + 10)
+  expect_identical(p1$history(), p2$history())
+  expect_identical(p1$state(), p2$state())
+})


### PR DESCRIPTION
This PR introduces support for the `initial_log_likelihood` argument to `particle_filter` and `deterministic_filter`; with this, some additional likelihood of the parameters can be considered in addition to that from the time series.

Because this is part of the filter, it should carry directly through things like the pmcmc