### PR TITLE
Add support for one-shot nested update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.8.2
+Version: 0.8.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc_control.R
+++ b/R/pmcmc_control.R
@@ -145,6 +145,12 @@
 ##'   or on desired run-time, for example updating fixed parameters is
 ##'   quicker so more varied steps could be more efficient.
 ##'
+##' @param nested_update_both If `FALSE` (default) then alternates
+##'   between proposing fixed and varied parameter updates according
+##'   to the ratio in `nested_step_ratio`. If `TRUE` then proposes
+##'   fixed and varied parameters simultaneously and collectively
+##'   accepts/rejects them, `nested_step_ratio` is ignored.
+##'
 ##' @param filter_early_exit Logical, indicating if we should allow
 ##'   the particle filter to exit early for points that will not be
 ##'   accepted. Only use this if your log-likelihood never increases
@@ -184,7 +190,8 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
                           use_parallel_seed = FALSE,
                           save_state = TRUE, save_restart = NULL,
                           save_trajectories = FALSE, progress = FALSE,
-                          nested_step_ratio = 1, filter_early_exit = FALSE,
+                          nested_step_ratio = 1, nested_update_both = FALSE,
+                          filter_early_exit = FALSE,
                           n_burnin = NULL, n_steps_retain = NULL) {
   assert_scalar_positive_integer(n_steps)
   assert_scalar_positive_integer(n_chains)
@@ -231,6 +238,7 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
     assert_strictly_increasing(save_restart)
   }
 
+  assert_scalar_logical(nested_update_both)
   ok <- test_integer(nested_step_ratio) || test_integer(1 / nested_step_ratio)
   if (!ok) {
     stop(sprintf("Either 'nested_step_ratio' (%g) or 1/'nested_step_ratio'
@@ -252,6 +260,7 @@ pmcmc_control <- function(n_steps, n_chains = 1L, n_threads_total = NULL,
               save_trajectories = save_trajectories,
               progress = progress,
               filter_early_exit = filter_early_exit,
+              nested_update_both = nested_update_both,
               nested_step_ratio = nested_step_ratio)
   ret[names(filter)] <- filter
 

--- a/R/pmcmc_state.R
+++ b/R/pmcmc_state.R
@@ -116,8 +116,8 @@ pmcmc_state <- R6::R6Class(
       }
     },
 
-    update_fixed = function() {
-      prop_pars <- private$pars$propose(private$curr_pars, type = "fixed")
+    update_combined = function(type) {
+      prop_pars <- private$pars$propose(private$curr_pars, type = type)
       prop_lprior <- private$pars$prior(prop_pars)
 
       u <- runif(1)
@@ -134,6 +134,14 @@ pmcmc_state <- R6::R6Class(
         private$curr_lpost <- prop_lpost
         private$update_particle_history()
       }
+    },
+
+    update_fixed = function() {
+      private$update_combined("fixed")
+    },
+
+    update_both = function() {
+      private$update_combined("both")
     },
 
     update_varied = function() {
@@ -199,6 +207,8 @@ pmcmc_state <- R6::R6Class(
         update <- update_single(private$update_varied)
       } else if (length(pars$names("varied")) == 0) {
         update <- update_single(private$update_fixed)
+      } else if (private$control$nested_update_both) {
+        update <- update_single(private$update_both)
       } else {
         update <- update_alternate(private$update_fixed,
                                    private$update_varied,

--- a/man/pmcmc_control.Rd
+++ b/man/pmcmc_control.Rd
@@ -18,6 +18,7 @@ pmcmc_control(
   save_trajectories = FALSE,
   progress = FALSE,
   nested_step_ratio = 1,
+  nested_update_both = FALSE,
   filter_early_exit = FALSE,
   n_burnin = NULL,
   n_steps_retain = NULL
@@ -128,6 +129,12 @@ iterations updating the fixed and varied parameters. Sensible choices
 of this parameter may depend on the true ratio of fixed:varied parameters
 or on desired run-time, for example updating fixed parameters is
 quicker so more varied steps could be more efficient.}
+
+\item{nested_update_both}{If \code{FALSE} (default) then alternates
+between proposing fixed and varied parameter updates according
+to the ratio in \code{nested_step_ratio}. If \code{TRUE} then proposes
+fixed and varied parameters simultaneously and collectively
+accepts/rejects them, \code{nested_step_ratio} is ignored.}
 
 \item{filter_early_exit}{Logical, indicating if we should allow
 the particle filter to exit early for points that will not be


### PR DESCRIPTION
An implementation of the one-shot update based on #131, but in the context of the new nested pmcmc.

Fixes #131