### PR TITLE
Allow use of compiled compare in more places

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -84,6 +84,10 @@ jobs:
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+
       - name: Upload check results
         if: failure()
         uses: actions/upload-artifact@main

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -84,10 +84,6 @@ jobs:
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-
       - name: Upload check results
         if: failure()
         uses: actions/upload-artifact@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
     callr (>= 3.7.0),
-    dust (>= 0.11.20),
+    dust (>= 0.11.23),
     processx,
     progress (>= 1.2.0)
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,6 @@ Suggests:
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Remotes:
-    mrc-ide/dust@i177-partial-filter,
+    mrc-ide/dust,
     mrc-ide/odin.dust
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.8.3
+Version: 0.8.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),
@@ -40,6 +40,6 @@ Suggests:
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Remotes:
-    mrc-ide/dust,
+    mrc-ide/dust@i177-partial-filter,
     mrc-ide/odin.dust
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.8.4
+
+* Compiled compare functions now supported in more places - `particle_deterministic` and multistage models (#177)
+
 # mcstate 0.8.3
 
 * Overhaul `mcstate::pmcmc_chains_*` to always use a file for communication, making them easier to understand and more robust (#179)

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -116,9 +116,7 @@ particle_deterministic <- R6::R6Class(
       assert_function_or_null(constant_log_likelihood)
       assert_is(data, "particle_filter_data")
 
-      ## NOTE: unlike the particle filter, there is no support for
-      ## using a compiled compare function here
-      assert_function(compare)
+      check_compare(compare, model)
 
       ## NOTE: unlike the particle filter, there is no support for GPU
       ## here (probably never will be)

--- a/R/deterministic_state.R
+++ b/R/deterministic_state.R
@@ -113,16 +113,6 @@ particle_deterministic_state <- R6::R6Class(
 
       history <- self$history
       save_history <- !is.null(history)
-      save_history_index <- self$history$index
-
-      if (save_history) {
-        ## Some work here to make sure that at this point we have the
-        ## correct index.  See also the particle filter - it's not
-        ## clear why we do this here and not just on initialisation
-        ## which would be much cleaner.
-        model$set_index(save_history_index)
-        on.exit(model$set_index(integer(0)))
-      }
 
       res <- model$filter(step, save_history, private$save_restart_step)
 
@@ -130,7 +120,7 @@ particle_deterministic_state <- R6::R6Class(
       self$current_step_index <- step_index
       if (save_history) {
         self$history <- list(value = res$trajectories,
-                             index = save_history_index)
+                             index = self$history$index)
       }
       self$restart_state <- res$snapshots
       self$log_likelihood
@@ -193,7 +183,6 @@ particle_deterministic_state <- R6::R6Class(
                                seed = NULL, deterministic = TRUE,
                                pars_multi = pars_multi)
         if (is.null(compare)) {
-          model$set_index(integer(0))
           model$set_data(data_split)
         }
       } else {
@@ -209,7 +198,9 @@ particle_deterministic_state <- R6::R6Class(
         index_data <- NULL
       } else {
         index_data <- support$index(model, index)
-        if (!is.null(compare)) {
+        if (is.null(compare)) {
+          model$set_index(index_data$predict)
+        } else {
           model$set_index(index_data$index)
         }
       }

--- a/R/deterministic_state.R
+++ b/R/deterministic_state.R
@@ -30,144 +30,9 @@ particle_deterministic_state <- R6::R6Class(
     save_history = NULL,
     save_restart_step = NULL,
     save_restart = NULL,
-    support = NULL
-  ),
+    support = NULL,
 
-  public = list(
-    ##' @field model The dust model being simulated
-    model = NULL,
-
-    ##' @field history The particle history, if created with
-    ##'   `save_history = TRUE`.
-    history = NULL,
-
-    ##' @field restart_state Full model state at a series of points in
-    ##'   time, if the model was created with non-`NULL` `save_restart`.
-    ##'   This is a 3d array as described in [mcstate::particle_filter]
-    restart_state = NULL,
-
-    ##' @field log_likelihood The log-likelihood so far. This starts at
-    ##'   0 when initialised and accumulates value for each step taken.
-    log_likelihood = NULL,
-
-    ##' @field current_step_index The index of the last completed step.
-    current_step_index = 0L,
-
-    ## As for private fields; missing
-    ## n_particles, gpu_config, min_log_likelihood but also missing seed
-    ##' @description Initialise the deterministic particle state. Ordinarily
-    ##' this should not be called by users, and so arguments are barely
-    ##' documented.
-    ##'
-    ##' @param pars Parameters for a single phase
-    ##' @param generator A dust generator object
-    ##' @param model If the generator has previously been initialised
-    ##' @param data A [mcstate::particle_filter_data] data object
-    ##' @param data_split The same data as `data` but split by step
-    ##' @param steps A matrix of step beginning and ends
-    ##' @param n_threads The number of threads to use
-    ##' @param initial Initial condition function (or `NULL`)
-    ##' @param index Index function (or `NULL`)
-    ##' @param compare Compare function
-    ##' @param constant_log_likelihood Constant log likelihood function
-    ##' @param save_history Logical, indicating if we should save history
-    ##' @param save_restart Vector of steps to save restart at
-    initialize = function(pars, generator, model, data, data_split, steps,
-                          n_threads, initial, index, compare,
-                          constant_log_likelihood,
-                          save_history, save_restart) {
-      pars_multi <- inherits(data, "particle_filter_data_nested")
-      support <- particle_deterministic_state_support(pars_multi)
-
-      ## This adds an extra dimension (vs using NULL), which is not
-      ## amazing, but it does simplify logic in a few places and keeps
-      ## this behaving more similarly to the particle filter.
-      n_particles <- 1L
-      if (is.null(model)) {
-        model <- generator$new(pars = pars, step = steps[[1]],
-                               n_particles = n_particles, n_threads = n_threads,
-                               seed = NULL, deterministic = TRUE,
-                               pars_multi = pars_multi)
-      } else {
-        model$update_state(pars = pars, step = steps[[1]])
-      }
-
-      if (!is.null(initial)) {
-        initial_data <- support$initial(model, initial, pars, n_particles)
-        model$update_state(state = initial_data)
-      }
-
-      if (is.null(index)) {
-        index_data <- NULL
-      } else {
-        index_data <- support$index(model, index)
-        model$set_index(index_data$index)
-      }
-
-      ## The model shape is [n_particles, <any multi-par structure>]
-      shape <- model$shape()
-
-      if (save_history) {
-        len <- nrow(steps) + 1L
-        state <- model$state(index_data$predict)
-        history_value <- array(NA_real_, c(dim(state), len))
-        array_last_dimension(history_value, 1) <- state
-        rownames(history_value) <- names(index_data$predict)
-        self$history <- list(
-          value = history_value,
-          index = index_data$predict)
-      } else {
-        self$history <- NULL
-      }
-
-      save_restart_step <- check_save_restart(save_restart, data)
-      if (length(save_restart_step) > 0) {
-        self$restart_state <-
-          array(NA_real_, c(model$n_state(), shape, length(save_restart)))
-      } else {
-        self$restart_state <- NULL
-      }
-
-      ## Constants
-      private$generator <- generator
-      private$pars <- pars
-      private$data <- data
-      private$data_split <- data_split
-      private$steps <- steps
-      private$n_threads <- n_threads
-      private$initial <- initial
-      private$index <- index
-      private$index_data <- index_data
-      private$compare <- compare
-      private$save_history <- save_history
-      private$save_restart_step <- save_restart_step
-      private$save_restart <- save_restart
-      private$support <- support
-
-      ## Variable (see also history)
-      self$model <- model
-      self$log_likelihood <- particle_filter_constant_log_likelihood(
-        pars, pars_multi, constant_log_likelihood)
-    },
-
-    ##' @description Run the deterministic particle to the end of the data.
-    ##' This is a convenience function around `$step()` which provides the
-    ##' correct value of `step_index`
-    run = function() {
-      self$step(nrow(private$steps))
-    },
-
-    ##' @description Take a step with the deterministic particle. This moves
-    ##' the system forward one step within the *data* (which
-    ##' may correspond to more than one step with your model) and
-    ##' returns the likelihood so far.
-    ##'
-    ##' @param step_index The step *index* to move to. This is not the same
-    ##' as the model step, nor time, so be careful (it's the index within
-    ##' the data provided to the filter). It is an error to provide
-    ##' a value here that is lower than the current step index, or past
-    ##' the end of the data.
-    step = function(step_index) {
+    step_r = function(step_index) {
       curr <- self$current_step_index
       check_step(curr, step_index, private$steps)
 
@@ -237,6 +102,187 @@ particle_deterministic_state <- R6::R6Class(
       self$current_step_index <- step_index
 
       log_likelihood
+    },
+
+    step_compiled = function(step_index) {
+      curr <- self$current_step_index
+      check_step(curr, step_index, private$steps, "Particle filter")
+      step <- private$steps[step_index, 2]
+
+      model <- self$model
+
+      history <- self$history
+      save_history <- !is.null(history)
+      save_history_index <- self$history$index
+
+      if (save_history) {
+        ## Some work here to make sure that at this point we have the
+        ## correct index.  See also the particle filter - it's not
+        ## clear why we do this here and not just on initialisation
+        ## which would be much cleaner.
+        model$set_index(save_history_index)
+        on.exit(model$set_index(integer(0)))
+      }
+
+      res <- model$filter(step, save_history, private$save_restart_step)
+
+      self$log_likelihood <- self$log_likelihood + res$log_likelihood
+      self$current_step_index <- step_index
+      if (save_history) {
+        self$history <- list(value = res$trajectories,
+                             index = save_history_index)
+      }
+      self$restart_state <- res$snapshots
+      self$log_likelihood
+    }
+  ),
+
+  public = list(
+    ##' @field model The dust model being simulated
+    model = NULL,
+
+    ##' @field history The particle history, if created with
+    ##'   `save_history = TRUE`.
+    history = NULL,
+
+    ##' @field restart_state Full model state at a series of points in
+    ##'   time, if the model was created with non-`NULL` `save_restart`.
+    ##'   This is a 3d array as described in [mcstate::particle_filter]
+    restart_state = NULL,
+
+    ##' @field log_likelihood The log-likelihood so far. This starts at
+    ##'   0 when initialised and accumulates value for each step taken.
+    log_likelihood = NULL,
+
+    ##' @field current_step_index The index of the last completed step.
+    current_step_index = 0L,
+
+    ## As for private fields; missing
+    ## n_particles, gpu_config, min_log_likelihood but also missing seed
+    ##' @description Initialise the deterministic particle state. Ordinarily
+    ##' this should not be called by users, and so arguments are barely
+    ##' documented.
+    ##'
+    ##' @param pars Parameters for a single phase
+    ##' @param generator A dust generator object
+    ##' @param model If the generator has previously been initialised
+    ##' @param data A [mcstate::particle_filter_data] data object
+    ##' @param data_split The same data as `data` but split by step
+    ##' @param steps A matrix of step beginning and ends
+    ##' @param n_threads The number of threads to use
+    ##' @param initial Initial condition function (or `NULL`)
+    ##' @param index Index function (or `NULL`)
+    ##' @param compare Compare function
+    ##' @param constant_log_likelihood Constant log likelihood function
+    ##' @param save_history Logical, indicating if we should save history
+    ##' @param save_restart Vector of steps to save restart at
+    initialize = function(pars, generator, model, data, data_split, steps,
+                          n_threads, initial, index, compare,
+                          constant_log_likelihood,
+                          save_history, save_restart) {
+      pars_multi <- inherits(data, "particle_filter_data_nested")
+      support <- particle_deterministic_state_support(pars_multi)
+
+      ## This adds an extra dimension (vs using NULL), which is not
+      ## amazing, but it does simplify logic in a few places and keeps
+      ## this behaving more similarly to the particle filter.
+      n_particles <- 1L
+      if (is.null(model)) {
+        model <- generator$new(pars = pars, step = steps[[1]],
+                               n_particles = n_particles, n_threads = n_threads,
+                               seed = NULL, deterministic = TRUE,
+                               pars_multi = pars_multi)
+        if (is.null(compare)) {
+          model$set_index(integer(0))
+          model$set_data(data_split)
+        }
+      } else {
+        model$update_state(pars = pars, step = steps[[1]])
+      }
+
+      if (!is.null(initial)) {
+        initial_data <- support$initial(model, initial, pars, n_particles)
+        model$update_state(state = initial_data)
+      }
+
+      if (is.null(index)) {
+        index_data <- NULL
+      } else {
+        index_data <- support$index(model, index)
+        if (!is.null(compare)) {
+          model$set_index(index_data$index)
+        }
+      }
+
+      ## The model shape is [n_particles, <any multi-par structure>]
+      shape <- model$shape()
+
+      if (save_history) {
+        len <- nrow(steps) + 1L
+        state <- model$state(index_data$predict)
+        history_value <- array(NA_real_, c(dim(state), len))
+        array_last_dimension(history_value, 1) <- state
+        rownames(history_value) <- names(index_data$predict)
+        self$history <- list(
+          value = history_value,
+          index = index_data$predict)
+      } else {
+        self$history <- NULL
+      }
+
+      save_restart_step <- check_save_restart(save_restart, data)
+      if (length(save_restart_step) > 0) {
+        self$restart_state <-
+          array(NA_real_, c(model$n_state(), shape, length(save_restart)))
+      } else {
+        self$restart_state <- NULL
+      }
+
+      ## Constants
+      private$generator <- generator
+      private$pars <- pars
+      private$data <- data
+      private$data_split <- data_split
+      private$steps <- steps
+      private$n_threads <- n_threads
+      private$initial <- initial
+      private$index <- index
+      private$index_data <- index_data
+      private$compare <- compare
+      private$save_history <- save_history
+      private$save_restart_step <- save_restart_step
+      private$save_restart <- save_restart
+      private$support <- support
+
+      ## Variable (see also history)
+      self$model <- model
+      self$log_likelihood <- particle_filter_constant_log_likelihood(
+        pars, pars_multi, constant_log_likelihood)
+    },
+
+    ##' @description Run the deterministic particle to the end of the data.
+    ##' This is a convenience function around `$step()` which provides the
+    ##' correct value of `step_index`
+    run = function() {
+      self$step(nrow(private$steps))
+    },
+
+    ##' @description Take a step with the deterministic particle. This moves
+    ##' the system forward one step within the *data* (which
+    ##' may correspond to more than one step with your model) and
+    ##' returns the likelihood so far.
+    ##'
+    ##' @param step_index The step *index* to move to. This is not the same
+    ##' as the model step, nor time, so be careful (it's the index within
+    ##' the data provided to the filter). It is an error to provide
+    ##' a value here that is lower than the current step index, or past
+    ##' the end of the data.
+    step = function(step_index) {
+      if (is.null(private$compare)) {
+        private$step_compiled(step_index)
+      } else {
+        private$step_r(step_index)
+      }
     },
 
     ##' @description Create a new `deterministic_particle_state` object based

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -199,13 +199,7 @@ particle_filter <- R6::R6Class(
       assert_function_or_null(constant_log_likelihood)
       assert_is(data, "particle_filter_data")
 
-      if (is.null(compare)) {
-        if (!model$public_methods$has_compare()) {
-          stop("Your model does not have a built-in 'compare' function")
-        }
-      } else {
-        assert_function(compare)
-      }
+      check_compare(compare, model)
 
       if (!is.null(gpu_config)) {
         if (!model$public_methods$has_gpu_support(TRUE)) {
@@ -793,4 +787,15 @@ particle_filter_pars_nested <- function(pars, n_populations) {
   }
 
   ret
+}
+
+
+check_compare <- function(compare, model) {
+  if (is.null(compare)) {
+    if (!model$public_methods$has_compare()) {
+      stop("Your model does not have a built-in 'compare' function")
+    }
+  } else {
+    assert_function(compare)
+  }
 }

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -147,12 +147,6 @@ particle_filter_state <- R6::R6Class(
 
       history <- self$history
       save_history <- !is.null(history)
-      save_history_index <- self$history$index
-
-      if (save_history) {
-        model$set_index(save_history_index)
-        on.exit(model$set_index(integer(0)))
-      }
 
       res <- model$filter(step, save_history, private$save_restart_step)
 
@@ -161,7 +155,7 @@ particle_filter_state <- R6::R6Class(
       self$current_step_index <- step_index
       if (save_history) {
         self$history <- list(value = res$trajectories,
-                             index = save_history_index)
+                             index = self$history$index)
       }
       self$restart_state <- res$snapshots
       self$log_likelihood
@@ -228,7 +222,6 @@ particle_filter_state <- R6::R6Class(
                                seed = seed, gpu_config = gpu_config,
                                pars_multi = pars_multi)
         if (is.null(compare)) {
-          model$set_index(integer(0))
           model$set_data(data_split)
         }
       } else {
@@ -244,8 +237,10 @@ particle_filter_state <- R6::R6Class(
         index_data <- NULL
       } else {
         index_data <- support$index(model, index)
-        if (!is.null(compare) && !is.null(index_data$run)) {
+        if (!is.null(compare)){
           model$set_index(index_data$run)
+        } else {
+          model$set_index(index_data$state)
         }
       }
 

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -237,7 +237,7 @@ particle_filter_state <- R6::R6Class(
         index_data <- NULL
       } else {
         index_data <- support$index(model, index)
-        if (!is.null(compare)){
+        if (!is.null(compare)) {
           model$set_index(index_data$run)
         } else {
           model$set_index(index_data$state)

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -171,7 +171,7 @@ particle_filter_state <- R6::R6Class(
                              index = save_history_index)
       }
       self$restart_state <- res$snapshots
-      res$log_likelihood
+      self$log_likelihood
     }
   ),
 

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -40,12 +40,6 @@ particle_filter_state <- R6::R6Class(
       compare <- private$compare
       nested <- inherits(private$data, "particle_filter_data_nested")
 
-      ## This needs a little work in dust:
-      ## https://github.com/mrc-ide/dust/issues/177
-      if (is.null(compare)) {
-        stop("Can't use low-level step with compiled particle filter (yet)")
-      }
-
       steps <- private$steps
       data_split <- private$data_split
       pars <- private$pars

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -157,7 +157,6 @@ particle_filter_state <- R6::R6Class(
 
       if (save_history) {
         model$set_index(save_history_index)
-        ## What was the idea here?
         on.exit(model$set_index(integer(0)))
       }
 

--- a/tests/testthat/compare_variable.cpp
+++ b/tests/testthat/compare_variable.cpp
@@ -1,0 +1,13 @@
+// [[odin.dust::compare_data(observed = real_type)]]
+// [[odin.dust::compare_function]]
+template <typename T>
+typename T::real_type
+compare(const typename T::real_type * state,
+        const typename T::data_type& data,
+        const typename T::internal_type internal,
+        std::shared_ptr<const typename T::shared_type> shared,
+        typename T::rng_state_type& rng_state) {
+  typedef typename T::real_type real_type;
+  const real_type mu = 0, sd = 1;
+  return dust::density::normal(state[0] - data.observed, mu, sd, true);
+}

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -438,6 +438,7 @@ example_variable <- function() {
     update(x[2:len]) <- i + step / 10
     initial(x[]) <- 0
     dim(x) <- len
+    config(compare) <- "compare_variable.cpp"
   }, verbose = FALSE)
 
   data <- particle_filter_data(data.frame(time = 1:50, observed = rnorm(50)),

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -362,3 +362,37 @@ test_that("Can offset the initial likelihood", {
   expect_identical(p1$history(), p2$history())
   expect_identical(p1$state(), p2$state())
 })
+
+
+test_that("Can use compiled compare", {
+  dat <- example_sir()
+  p1 <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
+  p2 <- particle_deterministic$new(dat$data, dat$model, NULL, dat$index)
+  pars <- list(exp_noise = Inf)
+  ## there's a discrepency here which ironically goes away with
+  ## non-infinite noise due to combination of sum over small numbers
+  ## and slightly different density calculation accuracy.
+  expect_equal(p1$run(pars), p2$run(pars), tolerance = 2e-5)
+})
+
+
+test_that("Can get history with compiled particle filter", {
+  dat <- example_sir()
+  set.seed(1)
+
+  model <- dust::dust_example("sir")
+  p1 <- particle_deterministic$new(dat$data, dat$model, dat$compare,
+                                   index = dat$index)
+  p2 <- particle_deterministic$new(dat$data, model, NULL,
+                                   index = dat$index)
+
+  pars <- list(exp_noise = Inf)
+
+  p1$run(pars, save_history = TRUE)
+  p2$run(pars, save_history = TRUE)
+
+  expect_equal(dim(p1$history()), dim(p2$history()))
+  expect_true(all(diff(t(p2$history()[3, , ])) >= 0))
+  expect_equal(dim(p1$history(1L)), dim(p2$history(1L)))
+  expect_equal(p1$history(), p2$history())
+})

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -711,28 +711,6 @@ test_that("Can't run past the end of the data", {
 })
 
 
-test_that("Can't partially run a compiled filter", {
-  dat <- example_sir()
-  p <- particle_filter$new(dat$data, dat$model, 10, NULL,
-                           index = dat$index, seed = 1L)
-  expect_error(p$run_begin()$step(5),
-               "Can't use low-level step with compiled particle filter (yet)",
-               fixed = TRUE)
-})
-
-
-test_that("Can't partially run a compiled filter (nested)", {
-  dat <- example_sir_shared()
-  pars <- list(list(beta = 0.2, gamma = 0.1),
-               list(beta = 0.3, gamma = 0.1))
-  p <- particle_filter$new(dat$data, dat$model, 10, NULL,
-                           index = dat$index)
-  expect_error(p$run_begin(pars)$step(5),
-               "Can't use low-level step with compiled particle filter (yet)",
-               fixed = TRUE)
-})
-
-
 test_that("Can fork a particle_filter_state object", {
   dat <- example_sir()
   n_particles <- 42

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -601,6 +601,21 @@ test_that("prevent using compiled compare where model does not support it", {
 })
 
 
+test_that("can't get partial likelihood with compiled compare", {
+  dat <- example_sir()
+  n_particles <- 100
+  set.seed(1)
+
+  model <- dust::dust_example("sir")
+  p <- particle_filter$new(dat$data, model, n_particles, NULL,
+                           index = dat$index)
+  obj <- p$run_begin()
+  expect_error(
+    obj$step(10, TRUE),
+    "'partial' not supported with compiled compare")
+})
+
+
 test_that("incrementally run a particle filter", {
   dat <- example_sir()
   n_particles <- 42

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -631,6 +631,33 @@ test_that("incrementally run a particle filter", {
 })
 
 
+test_that("incrementally run a compiled particle filter", {
+  dat <- example_sir()
+  n_particles <- 42
+
+  set.seed(1)
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, NULL,
+                           index = dat$index, seed = 1L)
+  cmp <- p1$run()
+
+  set.seed(1)
+  p2 <- particle_filter$new(dat$data, dat$model, n_particles, NULL,
+                            index = dat$index, seed = 1L)
+
+  n <- nrow(dat$data)
+  ans <- numeric(n)
+  obj <- p2$run_begin()
+  expect_s3_class(obj, "particle_filter_state")
+  for (i in seq_len(n)) {
+    ans[[i]] <- obj$step(i)
+  }
+
+  expect_identical(obj$log_likelihood, cmp)
+  expect_identical(ans[[length(ans)]], cmp)
+  expect_true(all(diff(ans) < 0))
+})
+
+
 test_that("Can't step a particle filter object past its end", {
   dat <- example_sir()
   n_particles <- 42


### PR DESCRIPTION
This PR allows use of the compiled compare function in a few more places, using support added in https://github.com/mrc-ide/dust/pull/360

* deterministic models (was entirely unsupported)
* multistage models (required partially running the filter)

Merge https://github.com/mrc-ide/dust/pull/360 first and unpin branch
Fixes #177 

