### PR TITLE
Don't reset data each epoch with compiled compare

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.8.4
+Version: 0.8.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -209,7 +209,7 @@ particle_deterministic <- R6::R6Class(
         stop("'min_log_likelihood' cannot be used with particle_deterministic")
       }
       particle_deterministic_state$new(
-        pars, self$model, private$last_model, private$data,
+        pars, self$model, private$last_model[[1]], private$data,
         private$data_split, private$steps, private$n_threads,
         private$initial, private$index, private$compare,
         private$constant_log_likelihood,
@@ -227,7 +227,7 @@ particle_deterministic <- R6::R6Class(
       if (is.null(private$last_model)) {
         stop("Model has not yet been run")
       }
-      private$last_model$state(index_state)
+      last(private$last_model)$state(index_state)
     },
 
     ##' @description Extract the particle trajectories. Requires that
@@ -305,7 +305,7 @@ particle_deterministic <- R6::R6Class(
            compare = private$compare,
            constant_log_likelihood = private$constant_log_likelihood,
            n_threads = private$n_threads,
-           seed = filter_current_seed(private$last_model, NULL))
+           seed = filter_current_seed(last(private$last_model), NULL))
     },
 
     ##' @description
@@ -319,11 +319,6 @@ particle_deterministic <- R6::R6Class(
     ##'   verify that you can actually use the number of threads
     ##'   requested (based on environment variables and OpenMP support).
     set_n_threads = function(n_threads) {
-      prev <- private$n_threads
-      private$n_threads <- n_threads
-      if (!is.null(private$last_model)) {
-        private$last_model$set_n_threads(n_threads)
-      }
-      invisible(prev)
+      particle_filter_set_n_threads(private, n_threads)
     }
   ))

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -19,6 +19,7 @@ particle_deterministic <- R6::R6Class(
     index = NULL,
     compare = NULL,
     constant_log_likelihood = NULL,
+    last_stages = NULL,
     last_model = NULL,
     last_history = NULL,
     last_state = NULL,
@@ -167,20 +168,8 @@ particle_deterministic <- R6::R6Class(
     ##' (`-Inf` if the model is impossible)
     run = function(pars = list(), save_history = FALSE, save_restart = NULL,
                    min_log_likelihood = -Inf) {
-      assert_scalar_logical(save_history)
-      if (self$nested) {
-        n_populations <- length(attr(private$data, "populations"))
-        pars <- particle_filter_pars_nested(pars, n_populations)
-      }
-      is_multistage <- particle_filter_check_multistage_pars(
-        pars, private$last_model)
-      if (is_multistage) {
-        filter_run_multistage(self, private, pars, save_history, save_restart,
-                              min_log_likelihood)
-      } else {
-        filter_run_simple(self, private, pars, save_history, save_restart,
-                          min_log_likelihood)
-      }
+      filter_run(self, private, pars, save_history, save_restart,
+                 min_log_likelihood)
     },
 
     ##' @description Begin a deterministic run. This is part of the

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -172,7 +172,9 @@ particle_deterministic <- R6::R6Class(
         n_populations <- length(attr(private$data, "populations"))
         pars <- particle_filter_pars_nested(pars, n_populations)
       }
-      if (inherits(pars, "multistage_parameters")) {
+      is_multistage <- particle_filter_check_multistage_pars(
+        pars, private$last_model)
+      if (is_multistage) {
         filter_run_multistage(self, private, pars, save_history, save_restart,
                               min_log_likelihood)
       } else {

--- a/R/deterministic_state.R
+++ b/R/deterministic_state.R
@@ -280,13 +280,14 @@ particle_deterministic_state <- R6::R6Class(
     ##' on this one (same model, position in time within the data) but with
     ##' new parameters, to support the "multistage particle filter".
     ##'
+    ##' @param model A model object
+    ##'
     ##' @param pars New model parameters
     ##'
     ##' @param transform_state A function to transform the model state
     ##'   from the old to the new parameter set.  See
     ##'   [mcstate::multistage_epoch()] for details.
-    fork_multistage = function(pars, transform_state) {
-      model <- NULL
+    fork_multistage = function(model, pars, transform_state) {
       save_history <- !is.null(self$history)
       initial <- NULL
       constant_log_likelihood <- NULL

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -277,7 +277,9 @@ particle_filter <- R6::R6Class(
         n_populations <- length(attr(private$data, "populations"))
         pars <- particle_filter_pars_nested(pars, n_populations)
       }
-      if (inherits(pars, "multistage_parameters")) {
+      is_multistage <- particle_filter_check_multistage_pars(
+        pars, private$last_model)
+      if (is_multistage) {
         filter_run_multistage(self, private, pars, save_history, save_restart,
                               min_log_likelihood)
       } else {
@@ -794,6 +796,27 @@ particle_filter_set_n_threads <- function(private, n_threads) {
     }
   }
   invisible(prev)
+}
+
+
+particle_filter_check_multistage_pars <- function(pars, last_model) {
+  is_multistage <- inherits(pars, "multistage_parameters")
+  if (!is.null(last_model)) {
+    n_stages_prev <- length(last_model)
+    n_stages_given <- if (is_multistage) length(pars) else 1L
+    if (n_stages_prev != n_stages_given) {
+      if (n_stages_prev == 1) {
+        stop(sprintf(
+          "Expected single-stage parameters (but given one with %d stages)",
+          n_stages_given))
+      } else {
+        stop(sprintf(
+          "Expected multistage_pars with %d stages (but given one with %d)",
+          n_stages_prev, n_stages_given))
+      }
+    }
+  }
+  is_multistage
 }
 
 

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -328,19 +328,24 @@ particle_filter_state <- R6::R6Class(
     ##' allowed.  The model is not rerun to the current point, just
     ##' transformed at that point.
     ##'
+    ##' @param model A model object (or NULL)
+    ##'
     ##' @param pars New model parameters
     ##'
     ##' @param transform_state A function to transform the model state
     ##'   from the old to the new parameter set.  See
     ##'   [mcstate::multistage_epoch()] for details.
-    fork_multistage = function(pars, transform_state) {
+    fork_multistage = function(model, pars, transform_state) {
       stopifnot(!private$gpu) # this won't work
       gpu_config <- NULL
-      model <- NULL
       seed <- self$model$rng_state()
       save_history <- !is.null(self$history)
       initial <- NULL
       constant_log_likelihood <- NULL
+
+      if (!is.null(model)) {
+        model$set_rng_state(seed)
+      }
 
       if (is.null(pars)) {
         pars <- self$model$pars()

--- a/tests/testthat/test-particle-filter-multistage.R
+++ b/tests/testthat/test-particle-filter-multistage.R
@@ -555,3 +555,37 @@ test_that("Confirm nested filter is correct", {
   expect_identical(is.na(h_staged), is.na(h_cmp))
   expect_identical(h_staged, h_cmp)
 })
+
+
+test_that("Can't change numbers of stages after creation", {
+  dat <- example_sir()
+
+  index <- function(info) {
+    list(run = 5L, state = c(S = 1, I = 2, R = 3))
+  }
+  pars_base <- dat$pars$model(dat$pars$initial())
+  pars0 <- pars_base
+  pars1 <- multistage_parameters(pars_base, list())
+  pars2 <- multistage_parameters(pars_base, list(multistage_epoch(10)))
+
+  filter1 <- particle_filter$new(dat$data, dat$model, 42, dat$compare,
+                                 index = index, seed = 1L)
+  filter1$run(pars0)
+  expect_silent(filter1$run(pars1))
+  expect_error(
+    filter1$run(pars2),
+    "Expected single-stage parameters (but given one with 2 stages)",
+    fixed = TRUE)
+
+  filter2 <- particle_filter$new(dat$data, dat$model, 42, dat$compare,
+                                 index = index, seed = 1L)
+  filter2$run(pars2)
+  expect_error(
+    filter2$run(pars0),
+    "Expected multistage_pars with 2 stages (but given one with 1)",
+    fixed = TRUE)
+  expect_error(
+    filter2$run(pars1),
+    "Expected multistage_pars with 2 stages (but given one with 1)",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-particle-filter-multistage.R
+++ b/tests/testthat/test-particle-filter-multistage.R
@@ -101,8 +101,8 @@ test_that("A trivial multistage filter is identical to single stage", {
 
   expect_identical(ll1, ll2)
   expect_identical(
-    r6_private(filter1)$last_model$rng_state(),
-    r6_private(filter2)$last_model$rng_state())
+    r6_private(filter1)$last_model[[1]]$rng_state(),
+    r6_private(filter2)$last_model[[1]]$rng_state())
 
   expect_identical(filter1$history(), filter2$history())
 })
@@ -131,8 +131,8 @@ test_that("An effectless multistage filter is identical to single stage", {
 
   expect_identical(ll1, ll2)
   expect_identical(
-    r6_private(filter1)$last_model$rng_state(),
-    r6_private(filter2)$last_model$rng_state())
+    r6_private(filter1)$last_model[[1]]$rng_state(),
+    r6_private(filter2)$last_model[[3]]$rng_state())
 
   expect_identical(filter1$history(), filter2$history())
   expect_identical(filter1$restart_state(), filter2$restart_state())

--- a/tests/testthat/test-particle-filter-multistage.R
+++ b/tests/testthat/test-particle-filter-multistage.R
@@ -608,7 +608,7 @@ test_that("can run a particle filter over a subset of data, twice", {
                  transform_state = dat$transform_state))
   pars <- multistage_parameters(pars_base, epochs)
 
-  data <-subset(dat$data, time_start >= 30)
+  data <- subset(dat$data, time_start >= 30)
   filter <- particle_filter$new(data, dat$model, 42, dat$compare,
                                 index = index, seed = 1L)
   filter$run(pars)

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -419,13 +419,13 @@ test_that("can change the number of threads (null model)", {
   expect_equal(p$set_n_threads(2), 1)
   expect_equal(r6_private(p)$n_threads, 2)
   p$run()
-  expect_equal(r6_private(p)$last_model$n_threads(), 2)
+  expect_equal(r6_private(p)$last_model[[1]]$n_threads(), 2)
 
   expect_equal(p$set_n_threads(1), 2)
   expect_equal(r6_private(p)$n_threads, 1)
-  expect_equal(r6_private(p)$last_model$n_threads(), 1)
+  expect_equal(r6_private(p)$last_model[[1]]$n_threads(), 1)
   p$run()
-  expect_equal(r6_private(p)$last_model$n_threads(), 1)
+  expect_equal(r6_private(p)$last_model[[1]]$n_threads(), 1)
 })
 
 

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -180,11 +180,11 @@ test_that("collecting state from model yields an RNG state", {
                     control = pmcmc_control(5, save_state = TRUE))
 
   expect_identical(
-    r6_private(p1)$last_model$rng_state(),
-    r6_private(p2)$last_model$rng_state())
+    r6_private(p1)$last_model[[1]]$rng_state(),
+    r6_private(p2)$last_model[[1]]$rng_state())
   expect_identical(
     results2$predict$filter$seed,
-    r6_private(p1)$last_model$rng_state()[1:32])
+    r6_private(p1)$last_model[[1]]$rng_state()[1:32])
   expect_false(
     identical(results2$predict$filter$seed, results3$predict$filter$seed))
 })


### PR DESCRIPTION
For the sircovid model, `$set_data()` is very expensive and should only be done on the first call to the particle filter.  This PR persists the created models after initial filter creation (including validating that the number of epochs do not change).

With the multiregion deterministic model I see a decrease in runtime from 7.5s to 2.9s with this change!

Fixes #195 