### PR TITLE
i187 rename pars_multi -> nested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .Rproj.user
 .Rhistory
 .RData

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.8.6
+Version: 0.8.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/deterministic_state.R
+++ b/R/deterministic_state.R
@@ -170,8 +170,8 @@ particle_deterministic_state <- R6::R6Class(
                           n_threads, initial, index, compare,
                           constant_log_likelihood,
                           save_history, save_restart) {
-      pars_multi <- inherits(data, "particle_filter_data_nested")
-      support <- particle_deterministic_state_support(pars_multi)
+      nested <- inherits(data, "particle_filter_data_nested")
+      support <- particle_deterministic_state_support(nested)
 
       ## This adds an extra dimension (vs using NULL), which is not
       ## amazing, but it does simplify logic in a few places and keeps
@@ -181,7 +181,7 @@ particle_deterministic_state <- R6::R6Class(
         model <- generator$new(pars = pars, step = steps[[1]],
                                n_particles = n_particles, n_threads = n_threads,
                                seed = NULL, deterministic = TRUE,
-                               pars_multi = pars_multi)
+                               pars_multi = nested)
         if (is.null(compare)) {
           model$set_data(data_split)
         }
@@ -248,7 +248,7 @@ particle_deterministic_state <- R6::R6Class(
       ## Variable (see also history)
       self$model <- model
       self$log_likelihood <- particle_filter_constant_log_likelihood(
-        pars, pars_multi, constant_log_likelihood)
+        pars, nested, constant_log_likelihood)
     },
 
     ##' @description Run the deterministic particle to the end of the data.

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -213,14 +213,14 @@ particle_filter_state <- R6::R6Class(
                           n_particles, n_threads, initial, index, compare,
                           constant_log_likelihood, gpu_config, seed,
                           min_log_likelihood, save_history, save_restart) {
-      pars_multi <- inherits(data, "particle_filter_data_nested")
-      support <- particle_filter_state_support(pars_multi)
+      nested <- inherits(data, "particle_filter_data_nested")
+      support <- particle_filter_state_support(nested)
 
       if (is.null(model)) {
         model <- generator$new(pars = pars, step = steps[[1L]],
                                n_particles = n_particles, n_threads = n_threads,
                                seed = seed, gpu_config = gpu_config,
-                               pars_multi = pars_multi)
+                               pars_multi = nested)
         if (is.null(compare)) {
           model$set_data(data_split)
         }
@@ -289,7 +289,7 @@ particle_filter_state <- R6::R6Class(
       ## Variable (see also history)
       self$model <- model
       self$log_likelihood <- particle_filter_constant_log_likelihood(
-        pars, pars_multi, constant_log_likelihood)
+        pars, nested, constant_log_likelihood)
     },
 
     ##' @description Run the particle filter to the end of the data. This is
@@ -451,16 +451,16 @@ particle_filter_early_exit <- function(log_likelihood, min_log_likelihood) {
 }
 
 
-particle_filter_constant_log_likelihood <- function(pars, pars_multi,
+particle_filter_constant_log_likelihood <- function(pars, nested,
                                                     constant_log_likelihood) {
   if (is.null(constant_log_likelihood)) {
-    if (pars_multi) {
+    if (nested) {
       rep(0, length(pars))
     } else {
       0
     }
   } else {
-    if (pars_multi) {
+    if (nested) {
       vnapply(pars, constant_log_likelihood)
     } else {
       constant_log_likelihood(pars)


### PR DESCRIPTION
Fixes #187 
Although `pars_multi` is also a variable name in `dust` (and to change it there would be backwards incompatible as it is externally facing)