### PR TITLE
I193 skip tests if depdendencies are not installed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.8.7
+Version: 0.8.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/man/particle_deterministic_state.Rd
+++ b/man/particle_deterministic_state.Rd
@@ -143,12 +143,14 @@ Create a new \code{deterministic_particle_state} object based
 on this one (same model, position in time within the data) but with
 new parameters, to support the "multistage particle filter".
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_deterministic_state$fork_multistage(pars, transform_state)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_deterministic_state$fork_multistage(model, pars, transform_state)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{model}}{A model object}
+
 \item{\code{pars}}{New model parameters}
 
 \item{\code{transform_state}}{A function to transform the model state

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -169,12 +169,14 @@ model shape and arbitrary transformations of the state are
 allowed.  The model is not rerun to the current point, just
 transformed at that point.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter_state$fork_multistage(pars, transform_state)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter_state$fork_multistage(model, pars, transform_state)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{model}}{A model object (or NULL)}
+
 \item{\code{pars}}{New model parameters}
 
 \item{\code{transform_state}}{A function to transform the model state

--- a/tests/testthat/test-deterministic-multistage.R
+++ b/tests/testthat/test-deterministic-multistage.R
@@ -64,6 +64,7 @@ test_that("An effectless multistage filter is identical to single stage", {
 
 
 test_that("multistage, dimension changing, model agrees with single stage", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
   new_filter <- function() {
     set.seed(1)
@@ -128,6 +129,7 @@ test_that("multistage, dimension changing, model agrees with single stage", {
 
 
 test_that("Can't save restart when size changes", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   ## There's going to be some work here to update this so that it's
@@ -167,6 +169,7 @@ test_that("Can't save restart when size changes", {
 
 
 test_that("Confirm deterministic nested multistage is correct", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   ## We need some multipopulation data here:
@@ -247,6 +250,7 @@ test_that("Confirm deterministic nested multistage is correct", {
 
 
 test_that("Can run multistage with compiled", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   ## We need some multipopulation data here:
@@ -298,6 +302,7 @@ test_that("Can run multistage with compiled", {
 
 
 test_that("multistage model does not reuse data after initialisation", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
   pars_base <- list(len = 10)
   epochs <- list(

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -211,6 +211,7 @@ test_that("Can run deterministic filter without index", {
 
 
 test_that("initial passes args as expected", {
+  testthat::skip_if_not_installed("mockery")
   dat <- example_sir()
   initial <- mockery::mock(c(1000, 10, 0, 0, 0), cycle = TRUE)
   p <- particle_deterministic$new(dat$data, dat$model, dat$compare,

--- a/tests/testthat/test-particle-filter-multistage.R
+++ b/tests/testthat/test-particle-filter-multistage.R
@@ -181,6 +181,7 @@ test_that("Can transform state in the model", {
 
 
 test_that("Can transform state size", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   pars_base <- list(len = 10, sd = 1)
@@ -202,6 +203,7 @@ test_that("Can transform state size", {
 
 
 test_that("multistage, dimension changing, model agrees with single stage", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
   new_filter <- function() {
     set.seed(1)
@@ -278,6 +280,7 @@ test_that("Require named index for history-saving multistage filter", {
 
 
 test_that("Can't save restart when size changes", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   ## There's going to be some work here to update this so that it's
@@ -318,6 +321,7 @@ test_that("Can't save restart when size changes", {
 
 
 test_that("Prevent restart on epoch changes", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   ## There's going to be some work here to update this so that it's
@@ -353,6 +357,7 @@ test_that("Prevent restart on epoch changes", {
 
 
 test_that("Gracefully cope with early exit", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   ## There's going to be some work here to update this so that it's
@@ -437,6 +442,7 @@ test_that("Can filter multistage parameters based on data", {
 ## This is not a great test, but covers the key bits; that we filter
 ## down the parameters to the right set, in particular.
 test_that("Can run a multistage filter from part way through", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   pars_base <- list(len = 10, sd = 1)
@@ -477,6 +483,7 @@ test_that("Can run a multistage filter from part way through", {
 
 
 test_that("Confirm nested filter is correct", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   ## We need some multipopulation data here:
@@ -592,6 +599,7 @@ test_that("Can't change numbers of stages after creation", {
 
 
 test_that("can run a particle filter over a subset of data, twice", {
+  testthat::skip_if_not_installed("odin.dust")
   dat <- example_variable()
 
   index <- function(info) {

--- a/tests/testthat/test-pmcmc-nested.R
+++ b/tests/testthat/test-pmcmc-nested.R
@@ -89,6 +89,7 @@ test_that("pmcmc_check_initial_nested - error matrix initial", {
 
 
 test_that("pmcmc nested Uniform on unit square - fixed only", {
+  testthat::skip_if_not_installed("coda")
   dat <- example_uniform_shared(varied = FALSE)
   control <- pmcmc_control(200, save_state = FALSE, save_trajectories = FALSE)
 
@@ -106,6 +107,7 @@ test_that("pmcmc nested Uniform on unit square - fixed only", {
 
 
 test_that("pmcmc nested Uniform on unit square - varied only", {
+  testthat::skip_if_not_installed("coda")
   dat <- example_uniform_shared(fixed = FALSE)
   control <- pmcmc_control(200, save_state = FALSE, save_trajectories = FALSE)
 
@@ -123,6 +125,7 @@ test_that("pmcmc nested Uniform on unit square - varied only", {
 
 
 test_that("pmcmc nested Uniform on unit square", {
+  testthat::skip_if_not_installed("coda")
   dat <- example_uniform_shared()
   control <- pmcmc_control(201, save_state = FALSE, save_trajectories = FALSE)
 

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -5,6 +5,7 @@ context("pmcmc")
 ## sampler should be ok to run for ~10k iterations without taking too
 ## long to be annoying in tests.
 test_that("mcmc works for uniform distribution on unit square", {
+  testthat::skip_if_not_installed("coda")
   dat <- example_uniform()
   control <- pmcmc_control(1000, save_state = FALSE, save_trajectories = FALSE)
 
@@ -74,6 +75,7 @@ test_that("reflect parameters: upper", {
 
 
 test_that("proposal uses provided covariance structure", {
+  testthat::skip_if_not_installed("coda")
   dat <- example_uniform(proposal_kernel = matrix(0.1, 2, 2))
   control <- pmcmc_control(100, save_state = FALSE, save_trajectories = FALSE)
   res <- pmcmc(dat$pars, dat$filter, control = control)
@@ -84,6 +86,7 @@ test_that("proposal uses provided covariance structure", {
 
 
 test_that("run pmcmc with the particle filter and retain history", {
+  testthat::skip_if_not_installed("coda")
   proposal_kernel <- diag(2) * 1e-4
   row.names(proposal_kernel) <- colnames(proposal_kernel) <- c("beta", "gamma")
 


### PR DESCRIPTION
Can confirm this is working by running `devtools::check(env_vars=c("_R_CHECK_DEPENDS_ONLY_"=TRUE))` first on master to observe failures, then on this branch. Fixes #193 