### PR TITLE
add 'integer' arg to params, deprecate 'discrete'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.8.8
+Version: 0.9.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.9.0
+
+* Deprecated 'discrete' argument to parameters in favour of 'integer' - affects `if2_parameter`, `pmcmc_parameter`, `pmcmc_varied_parameter`, `smc2_parameter` 
+
 # mcstate 0.8.4
 
 * Compiled compare functions now supported in more places - `particle_deterministic` and multistage models (#177)

--- a/R/if2_parameters.R
+++ b/R/if2_parameters.R
@@ -17,9 +17,7 @@
 ##'   `Inf`). If given, then `initial` must be at most this
 ##'   value.
 ##'
-##' @param discrete Deprecated. Logical, indicating if this parameter is
-##'   discrete. If `TRUE` then the parameter will be rounded
-##'   after a new parameter is proposed.
+##' @param discrete Deprecated; use `integer` instead.
 ##'
 ##' @param integer Logical, indicating if this parameter is
 ##'   integer. If `TRUE` then the parameter will be rounded

--- a/R/pmcmc_parameters.R
+++ b/R/pmcmc_parameters.R
@@ -17,9 +17,7 @@
 ##'   `Inf`). If given, then `initial` must be at most this
 ##'   value.
 ##'
-##' @param discrete Deprecated. Logical, indicating if this parameter is
-##'   discrete. If `TRUE` then the parameter will be rounded
-##'   after a new parameter is proposed.
+##' @param discrete  Deprecated; use `integer` instead.
 ##'
 ##' @param integer Logical, indicating if this parameter is
 ##'   integer. If `TRUE` then the parameter will be rounded

--- a/R/pmcmc_parameters.R
+++ b/R/pmcmc_parameters.R
@@ -17,8 +17,12 @@
 ##'   `Inf`). If given, then `initial` must be at most this
 ##'   value.
 ##'
-##' @param discrete Logical, indicating if this parameter is
+##' @param discrete Deprecated. Logical, indicating if this parameter is
 ##'   discrete. If `TRUE` then the parameter will be rounded
+##'   after a new parameter is proposed.
+##'
+##' @param integer Logical, indicating if this parameter is
+##'   integer. If `TRUE` then the parameter will be rounded
 ##'   after a new parameter is proposed.
 ##'
 ##' @param prior A prior function (if not given an improper flat prior
@@ -30,9 +34,13 @@
 ##' @examples
 ##' pmcmc_parameter("a", 0.1)
 pmcmc_parameter <- function(name, initial, min = -Inf, max = Inf,
-                            discrete = FALSE, prior = NULL) {
+                            discrete, integer = FALSE, prior = NULL) {
+  if (!missing(discrete)) {
+    .Deprecated("integer", old = "discrete")
+    integer <- discrete
+  }
   assert_scalar_character(name)
-  assert_scalar_logical(discrete)
+  assert_scalar_logical(integer)
 
   if (initial < min) {
     stop(sprintf("'initial' must be >= 'min' (%s)", min))
@@ -59,7 +67,7 @@ pmcmc_parameter <- function(name, initial, min = -Inf, max = Inf,
   }
 
   ret <- list(name = name, initial = initial, min = min, max = max,
-              discrete = discrete, prior = prior)
+              integer = integer, prior = prior)
   class(ret) <- "pmcmc_parameter"
   ret
 }
@@ -107,7 +115,7 @@ pmcmc_parameters <- R6::R6Class(
     proposal = NULL,
     proposal_kernel = NULL,
     transform = NULL,
-    discrete = NULL,
+    integer = NULL,
     min = NULL,
     max = NULL
   ),
@@ -164,7 +172,7 @@ pmcmc_parameters <- R6::R6Class(
       private$proposal <- rmvnorm_generator(proposal)
       private$transform <- transform
 
-      private$discrete <- vlapply(private$parameters, "[[", "discrete",
+      private$integer <- vlapply(private$parameters, "[[", "integer",
                                   USE.NAMES = FALSE)
       private$min <- vnapply(private$parameters, "[[", "min",
                              USE.NAMES = FALSE)
@@ -184,12 +192,13 @@ pmcmc_parameters <- R6::R6Class(
     },
 
     ##' @description Return a `data.frame` with information about
-    ##' parameters (name, min, max, and discrete).
+    ##' parameters (name, min, max, and integer).
     summary = function() {
       data_frame(name = self$names(),
                  min = private$min,
                  max = private$max,
-                 discrete = private$discrete)
+                 discrete = private$integer,
+                 integer = private$integer)
     },
 
     ##' @description Compute the prior for a parameter vector
@@ -204,7 +213,7 @@ pmcmc_parameters <- R6::R6Class(
     ##' @description Propose a new parameter vector given a current parameter
     ##' vector. This proposes a new parameter vector given your current
     ##' vector and the variance-covariance matrix of your proposal
-    ##' kernel, discretises any discrete values, and reflects bounded
+    ##' kernel, rounds any integer values, and reflects bounded
     ##' parameters until they lie within `min`:`max`.
     ##'
     ##' @param theta a parameter vector in the same order as your
@@ -216,7 +225,7 @@ pmcmc_parameters <- R6::R6Class(
     ##' applied to the variance covariance matrix.
     propose = function(theta, scale = 1) {
       theta <- private$proposal(theta, scale)
-      theta[private$discrete] <- round(theta[private$discrete])
+      theta[private$integer] <- round(theta[private$integer])
       reflect_proposal(theta, private$min, private$max)
     },
 

--- a/R/pmcmc_parameters_nested.R
+++ b/R/pmcmc_parameters_nested.R
@@ -149,7 +149,7 @@ pmcmc_parameters_nested <- R6::R6Class(
     },
 
     ##' @description Return a `data.frame` with information about
-    ##' parameters (name, min, max, discrete, type (fixed or varied)
+    ##' parameters (name, min, max, integer, type (fixed or varied)
     ##' and population)
     summary = function() {
       populations <- self$populations()
@@ -229,7 +229,7 @@ pmcmc_parameters_nested <- R6::R6Class(
 
     ##' @description This proposes a new parameter matrix given your current
     ##' matrix and the variance-covariance matrices of the proposal
-    ##' kernels, discretises any discrete values, and reflects bounded
+    ##' kernels, rounds any integer values, and reflects bounded
     ##' parameters until they lie within `min`:`max`. Returns matrix with rows
     ##' corresponding to parameters and columns to populations (i.e.,
     ##' the same orientation as `theta`).

--- a/R/pmcmc_varied_parameter.R
+++ b/R/pmcmc_varied_parameter.R
@@ -50,7 +50,8 @@
 ##'   integer = TRUE,
 ##'   prior = list(dnorm, dexp))
 pmcmc_varied_parameter <- function(name, populations, initial, min = -Inf,
-                                   max = Inf, discrete, integer = FALSE, prior = NULL) {
+                                   max = Inf, discrete, integer = FALSE,
+                                   prior = NULL) {
   if (!missing(discrete)) {
     .Deprecated("integer", old = "discrete")
     integer <- discrete
@@ -73,7 +74,8 @@ pmcmc_varied_parameter <- function(name, populations, initial, min = -Inf,
     prior <- recycle(prior, len)
   }
 
-  params <- Map(pmcmc_parameter, name, initial, min, max, integer, prior)
+  params <- Map(pmcmc_parameter, name = name, initial = initial, min = min,
+                max = max, integer = integer, prior = prior)
   names(params) <- populations
   class(params) <- "pmcmc_varied_parameter"
 

--- a/R/pmcmc_varied_parameter.R
+++ b/R/pmcmc_varied_parameter.R
@@ -24,8 +24,12 @@
 ##'   value. Must be either length `n_pop` or `1`, in which case the same value
 ##'   is assumed for all populations.
 ##'
-##' @param discrete Logical, indicating if this parameter is
+##' @param discrete Deprecated. Logical, indicating if this parameter is
 ##'   discrete. If `TRUE` then the parameter will be rounded
+##'   after a new parameter is proposed.
+##'
+##' @param integer Logical, indicating if this parameter is
+##'   integer. If `TRUE` then the parameter will be rounded
 ##'   after a new parameter is proposed.
 ##'
 ##' @param prior A prior function (if not given an improper flat prior
@@ -43,17 +47,21 @@
 ##'   initial = c(100, 200),
 ##'   min = 0,
 ##'   max = Inf,
-##'   discrete = TRUE,
+##'   integer = TRUE,
 ##'   prior = list(dnorm, dexp))
 pmcmc_varied_parameter <- function(name, populations, initial, min = -Inf,
-                                   max = Inf, discrete = FALSE, prior = NULL) {
+                                   max = Inf, discrete, integer = FALSE, prior = NULL) {
+  if (!missing(discrete)) {
+    .Deprecated("integer", old = "discrete")
+    integer <- discrete
+  }
   assert_character(populations)
   len <- length(populations)
 
   initial <- recycle(initial, len)
   min <- recycle(min, len)
   max <- recycle(max, len)
-  discrete <- assert_scalar_logical(discrete)
+  integer <- assert_scalar_logical(integer)
 
   if (is.null(prior)) {
     prior <- function(p) 0
@@ -65,7 +73,7 @@ pmcmc_varied_parameter <- function(name, populations, initial, min = -Inf,
     prior <- recycle(prior, len)
   }
 
-  params <- Map(pmcmc_parameter, name, initial, min, max, discrete, prior)
+  params <- Map(pmcmc_parameter, name, initial, min, max, integer, prior)
   names(params) <- populations
   class(params) <- "pmcmc_varied_parameter"
 

--- a/R/pmcmc_varied_parameter.R
+++ b/R/pmcmc_varied_parameter.R
@@ -24,9 +24,7 @@
 ##'   value. Must be either length `n_pop` or `1`, in which case the same value
 ##'   is assumed for all populations.
 ##'
-##' @param discrete Deprecated. Logical, indicating if this parameter is
-##'   discrete. If `TRUE` then the parameter will be rounded
-##'   after a new parameter is proposed.
+##' @param discrete Deprecated; use `integer` instead.
 ##'
 ##' @param integer Logical, indicating if this parameter is
 ##'   integer. If `TRUE` then the parameter will be rounded

--- a/R/smc2_parameters.R
+++ b/R/smc2_parameters.R
@@ -27,9 +27,7 @@
 ##'   `Inf`). If given, then `initial` must be at most this
 ##'   value.
 ##'
-##' @param discrete Deprecated. Logical, indicating if this parameter is
-##'   discrete. If `TRUE` then the parameter will be rounded
-##'   after a new parameter is proposed.
+##' @param discrete Deprecated; use `integer` instead.
 ##'
 ##' @param integer Logical, indicating if this parameter is an
 ##'   integer. If `TRUE` then the parameter will be rounded

--- a/R/smc2_parameters.R
+++ b/R/smc2_parameters.R
@@ -12,7 +12,7 @@
 ##'   this will be a `r` probability function corresponding to the
 ##'   sampling version of your prior (e.g., you might use `runif` and
 ##'   `dunif` for `sample` and `prior`). If you provide `min`, `max`
-##'   or `discrete` you *must* ensure that your function returns
+##'   or `integer` you *must* ensure that your function returns
 ##'   values that satisfy these constraints, as this is not (yet)
 ##'   checked.
 ##'
@@ -27,8 +27,12 @@
 ##'   `Inf`). If given, then `initial` must be at most this
 ##'   value.
 ##'
-##' @param discrete Logical, indicating if this parameter is
+##' @param discrete Deprecated. Logical, indicating if this parameter is
 ##'   discrete. If `TRUE` then the parameter will be rounded
+##'   after a new parameter is proposed.
+##'
+##' @param integer Logical, indicating if this parameter is an
+##'   integer. If `TRUE` then the parameter will be rounded
 ##'   after a new parameter is proposed.
 ##'
 ##' @export
@@ -37,9 +41,13 @@
 ##'                         function(n) rnorm(n),
 ##'                         function(x) dnorm(n, log = TRUE))
 smc2_parameter <- function(name, sample, prior,
-                           min = -Inf, max = Inf, discrete = FALSE) {
+                           min = -Inf, max = Inf, discrete, integer = FALSE) {
+  if (!missing(discrete)) {
+    .Deprecated("integer", old = "discrete")
+    integer <- discrete
+  }
   assert_scalar_character(name)
-  assert_scalar_logical(discrete)
+  assert_scalar_logical(integer)
   assert_is(sample, "function")
   assert_is(prior, "function")
 
@@ -56,7 +64,7 @@ smc2_parameter <- function(name, sample, prior,
   ## but it's not going to be a massive timesink, and it would clean
   ## up the interface nicely.
   ret <- list(name = name, sample = sample, prior = prior,
-              min = min, max = max, discrete = discrete)
+              min = min, max = max, integer = integer)
   class(ret) <- "smc2_parameter"
   ret
 }
@@ -78,12 +86,12 @@ smc2_parameters <- R6::R6Class(
   private = list(
     parameters = NULL,
     transform = NULL,
-    discrete = NULL,
+    integer = NULL,
     min = NULL,
     max = NULL,
 
     constrain_parameters = function(theta) {
-      theta[, private$discrete] <- round(theta[, private$discrete])
+      theta[, private$integer] <- round(theta[, private$integer])
       min <- rep(private$min, each = nrow(theta))
       max <- rep(private$max, each = nrow(theta))
       theta[] <- reflect_proposal(theta, min, max)
@@ -117,7 +125,7 @@ smc2_parameters <- R6::R6Class(
       private$parameters <- parameters
       private$transform <- transform
 
-      private$discrete <- vlapply(private$parameters, "[[", "discrete",
+      private$integer <- vlapply(private$parameters, "[[", "integer",
                                   USE.NAMES = FALSE)
       private$min <- vnapply(private$parameters, "[[", "min",
                              USE.NAMES = FALSE)
@@ -140,12 +148,13 @@ smc2_parameters <- R6::R6Class(
     },
 
     ##' @description Return a `data.frame` with information about
-    ##' parameters (name, min, max, and discrete).
+    ##' parameters (name, min, max, and integer).
     summary = function() {
       data_frame(name = self$names(),
                  min = private$min,
                  max = private$max,
-                 discrete = private$discrete)
+                 discrete = private$integer,
+                 integer = private$integer)
     },
 
     ##' @description Compute the prior for a parameter vector
@@ -163,8 +172,8 @@ smc2_parameters <- R6::R6Class(
     },
 
     ##' @description Propose a new parameter vector given a current parameter
-    ##' vector and variance covariance matrix. After proposal, this discretises
-    ##' any discrete values, and reflects bounded parameters until they lie
+    ##' vector and variance covariance matrix. After proposal, this rounds
+    ##' any integer values, and reflects bounded parameters until they lie
     ##' within `min`:`max`.
     ##'
     ##' @param theta a parameter vector in the same order as your

--- a/man/if2_parameter.Rd
+++ b/man/if2_parameter.Rd
@@ -27,9 +27,7 @@ value.}
 \code{Inf}). If given, then \code{initial} must be at most this
 value.}
 
-\item{discrete}{Deprecated. Logical, indicating if this parameter is
-discrete. If \code{TRUE} then the parameter will be rounded
-after a new parameter is proposed.}
+\item{discrete}{Deprecated; use \code{integer} instead.}
 
 \item{integer}{Logical, indicating if this parameter is
 integer. If \code{TRUE} then the parameter will be rounded

--- a/man/if2_parameter.Rd
+++ b/man/if2_parameter.Rd
@@ -9,7 +9,8 @@ if2_parameter(
   initial,
   min = -Inf,
   max = Inf,
-  discrete = FALSE,
+  discrete,
+  integer = FALSE,
   prior = NULL
 )
 }
@@ -26,8 +27,12 @@ value.}
 \code{Inf}). If given, then \code{initial} must be at most this
 value.}
 
-\item{discrete}{Logical, indicating if this parameter is
+\item{discrete}{Deprecated. Logical, indicating if this parameter is
 discrete. If \code{TRUE} then the parameter will be rounded
+after a new parameter is proposed.}
+
+\item{integer}{Logical, indicating if this parameter is
+integer. If \code{TRUE} then the parameter will be rounded
 after a new parameter is proposed.}
 
 \item{prior}{A prior function (if not given an improper flat prior

--- a/man/if2_parameters.Rd
+++ b/man/if2_parameters.Rd
@@ -150,7 +150,7 @@ Return the names of the parameters
 \if{latex}{\out{\hypertarget{method-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{\link{data.frame}} with information about
-parameters (name, min, max, and discrete).
+parameters (name, min, max, and integer).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{if2_parameters$summary()}\if{html}{\out{</div>}}
 }

--- a/man/pmcmc_parameter.Rd
+++ b/man/pmcmc_parameter.Rd
@@ -27,9 +27,7 @@ value.}
 \code{Inf}). If given, then \code{initial} must be at most this
 value.}
 
-\item{discrete}{Deprecated. Logical, indicating if this parameter is
-discrete. If \code{TRUE} then the parameter will be rounded
-after a new parameter is proposed.}
+\item{discrete}{Deprecated; use \code{integer} instead.}
 
 \item{integer}{Logical, indicating if this parameter is
 integer. If \code{TRUE} then the parameter will be rounded

--- a/man/pmcmc_parameter.Rd
+++ b/man/pmcmc_parameter.Rd
@@ -9,7 +9,8 @@ pmcmc_parameter(
   initial,
   min = -Inf,
   max = Inf,
-  discrete = FALSE,
+  discrete,
+  integer = FALSE,
   prior = NULL
 )
 }
@@ -26,8 +27,12 @@ value.}
 \code{Inf}). If given, then \code{initial} must be at most this
 value.}
 
-\item{discrete}{Logical, indicating if this parameter is
+\item{discrete}{Deprecated. Logical, indicating if this parameter is
 discrete. If \code{TRUE} then the parameter will be rounded
+after a new parameter is proposed.}
+
+\item{integer}{Logical, indicating if this parameter is
+integer. If \code{TRUE} then the parameter will be rounded
 after a new parameter is proposed.}
 
 \item{prior}{A prior function (if not given an improper flat prior

--- a/man/pmcmc_parameters.Rd
+++ b/man/pmcmc_parameters.Rd
@@ -110,7 +110,7 @@ Return the names of the parameters
 \if{latex}{\out{\hypertarget{method-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{data.frame} with information about
-parameters (name, min, max, and discrete).
+parameters (name, min, max, and integer).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{pmcmc_parameters$summary()}\if{html}{\out{</div>}}
 }
@@ -141,7 +141,7 @@ parameters were defined in (see \verb{$names()} for that order.}
 Propose a new parameter vector given a current parameter
 vector. This proposes a new parameter vector given your current
 vector and the variance-covariance matrix of your proposal
-kernel, discretises any discrete values, and reflects bounded
+kernel, rounds any integer values, and reflects bounded
 parameters until they lie within \code{min}:\code{max}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{pmcmc_parameters$propose(theta, scale = 1)}\if{html}{\out{</div>}}

--- a/man/pmcmc_parameters_nested.Rd
+++ b/man/pmcmc_parameters_nested.Rd
@@ -162,7 +162,7 @@ fixed parameters are same across all populations.
 \if{latex}{\out{\hypertarget{method-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{data.frame} with information about
-parameters (name, min, max, discrete, type (fixed or varied)
+parameters (name, min, max, integer, type (fixed or varied)
 and population)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{pmcmc_parameters_nested$summary()}\if{html}{\out{</div>}}
@@ -205,7 +205,7 @@ named vector with names corresponding to populations.
 \subsection{Method \code{propose()}}{
 This proposes a new parameter matrix given your current
 matrix and the variance-covariance matrices of the proposal
-kernels, discretises any discrete values, and reflects bounded
+kernels, rounds any integer values, and reflects bounded
 parameters until they lie within \code{min}:\code{max}. Returns matrix with rows
 corresponding to parameters and columns to populations (i.e.,
 the same orientation as \code{theta}).

--- a/man/pmcmc_varied_parameter.Rd
+++ b/man/pmcmc_varied_parameter.Rd
@@ -35,9 +35,7 @@ is assumed for all populations.}
 value. Must be either length \code{n_pop} or \code{1}, in which case the same value
 is assumed for all populations.}
 
-\item{discrete}{Deprecated. Logical, indicating if this parameter is
-discrete. If \code{TRUE} then the parameter will be rounded
-after a new parameter is proposed.}
+\item{discrete}{Deprecated; use \code{integer} instead.}
 
 \item{integer}{Logical, indicating if this parameter is
 integer. If \code{TRUE} then the parameter will be rounded

--- a/man/pmcmc_varied_parameter.Rd
+++ b/man/pmcmc_varied_parameter.Rd
@@ -10,7 +10,8 @@ pmcmc_varied_parameter(
   initial,
   min = -Inf,
   max = Inf,
-  discrete = FALSE,
+  discrete,
+  integer = FALSE,
   prior = NULL
 )
 }
@@ -34,8 +35,12 @@ is assumed for all populations.}
 value. Must be either length \code{n_pop} or \code{1}, in which case the same value
 is assumed for all populations.}
 
-\item{discrete}{Logical, indicating if this parameter is
+\item{discrete}{Deprecated. Logical, indicating if this parameter is
 discrete. If \code{TRUE} then the parameter will be rounded
+after a new parameter is proposed.}
+
+\item{integer}{Logical, indicating if this parameter is
+integer. If \code{TRUE} then the parameter will be rounded
 after a new parameter is proposed.}
 
 \item{prior}{A prior function (if not given an improper flat prior
@@ -58,6 +63,6 @@ mcstate::pmcmc_varied_parameter(
   initial = c(100, 200),
   min = 0,
   max = Inf,
-  discrete = TRUE,
+  integer = TRUE,
   prior = list(dnorm, dexp))
 }

--- a/man/smc2_parameter.Rd
+++ b/man/smc2_parameter.Rd
@@ -4,7 +4,15 @@
 \alias{smc2_parameter}
 \title{Describe single pmcmc parameter}
 \usage{
-smc2_parameter(name, sample, prior, min = -Inf, max = Inf, discrete = FALSE)
+smc2_parameter(
+  name,
+  sample,
+  prior,
+  min = -Inf,
+  max = Inf,
+  discrete,
+  integer = FALSE
+)
 }
 \arguments{
 \item{name}{Name for the parameter (a string)}
@@ -14,7 +22,7 @@ representing the number of sampled to be returned. Typically
 this will be a \code{r} probability function corresponding to the
 sampling version of your prior (e.g., you might use \code{runif} and
 \code{dunif} for \code{sample} and \code{prior}). If you provide \code{min}, \code{max}
-or \code{discrete} you \emph{must} ensure that your function returns
+or \code{integer} you \emph{must} ensure that your function returns
 values that satisfy these constraints, as this is not (yet)
 checked.}
 
@@ -29,8 +37,12 @@ value.}
 \code{Inf}). If given, then \code{initial} must be at most this
 value.}
 
-\item{discrete}{Logical, indicating if this parameter is
+\item{discrete}{Deprecated. Logical, indicating if this parameter is
 discrete. If \code{TRUE} then the parameter will be rounded
+after a new parameter is proposed.}
+
+\item{integer}{Logical, indicating if this parameter is an
+integer. If \code{TRUE} then the parameter will be rounded
 after a new parameter is proposed.}
 }
 \description{

--- a/man/smc2_parameter.Rd
+++ b/man/smc2_parameter.Rd
@@ -37,9 +37,7 @@ value.}
 \code{Inf}). If given, then \code{initial} must be at most this
 value.}
 
-\item{discrete}{Deprecated. Logical, indicating if this parameter is
-discrete. If \code{TRUE} then the parameter will be rounded
-after a new parameter is proposed.}
+\item{discrete}{Deprecated; use \code{integer} instead.}
 
 \item{integer}{Logical, indicating if this parameter is an
 integer. If \code{TRUE} then the parameter will be rounded

--- a/man/smc2_parameters.Rd
+++ b/man/smc2_parameters.Rd
@@ -83,7 +83,7 @@ Return the names of the parameters
 \if{latex}{\out{\hypertarget{method-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{data.frame} with information about
-parameters (name, min, max, and discrete).
+parameters (name, min, max, and integer).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{smc2_parameters$summary()}\if{html}{\out{</div>}}
 }
@@ -112,8 +112,8 @@ parameters were defined in (see \verb{$names()} for that order.}
 \if{latex}{\out{\hypertarget{method-propose}{}}}
 \subsection{Method \code{propose()}}{
 Propose a new parameter vector given a current parameter
-vector and variance covariance matrix. After proposal, this discretises
-any discrete values, and reflects bounded parameters until they lie
+vector and variance covariance matrix. After proposal, this rounds
+any integer values, and reflects bounded parameters until they lie
 within \code{min}:\code{max}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{smc2_parameters$propose(theta, vcv)}\if{html}{\out{</div>}}

--- a/tests/testthat/test-if2-parameters.R
+++ b/tests/testthat/test-if2-parameters.R
@@ -8,7 +8,7 @@ test_that("can construct a parameter", {
   expect_equal(p$min, 0)
   expect_equal(p$max, 1)
   expect_equal(p$initial, 0.1)
-  expect_false(p$discrete)
+  expect_false(p$integer)
   expect_equal(p$prior(), 0)
 })
 
@@ -44,7 +44,7 @@ test_that("can construct and walk a set of parameters", {
   pars <- if2_parameters$new(
             list(if2_parameter("beta", 0.15, min = 0.1, max = 2),
                  if2_parameter("gamma", 0.05, min = 0, max = 1),
-                 if2_parameter("time", 10, discrete = TRUE)))
+                 if2_parameter("time", 10, integer = TRUE)))
   expect_s3_class(pars, "if2_parameters")
   expect_equal(pars$names(), c("beta", "gamma", "time"))
   expect_equal(pars$initial(), c("beta" = 0.15, "gamma" = 0.05, "time" = 10))
@@ -52,7 +52,7 @@ test_that("can construct and walk a set of parameters", {
                data_frame(name = c("beta", "gamma", "time"),
                           min = c(0.1, 0, -Inf),
                           max = c(2, 1, Inf),
-                          discrete = c(FALSE, FALSE, TRUE)))
+                          integer = c(FALSE, FALSE, TRUE)))
 
   n_pars <- length(pars$names())
   n_par_sets <- 5

--- a/tests/testthat/test-if2-parameters.R
+++ b/tests/testthat/test-if2-parameters.R
@@ -1,15 +1,24 @@
 context("IF2 (parameters)")
 
 test_that("can construct a parameter", {
-  p <- if2_parameter("a", 0.1, min = 0, max = 1)
+  p <- if2_parameter("a", 0.1, min = 0, max = 1, integer = TRUE)
 
   expect_s3_class(p, "if2_parameter")
   expect_equal(p$name, "a")
   expect_equal(p$min, 0)
   expect_equal(p$max, 1)
   expect_equal(p$initial, 0.1)
-  expect_false(p$integer)
+  expect_true(p$integer)
   expect_equal(p$prior(), 0)
+})
+
+
+test_that("Can use 'discrete' argument but deprecation warning is shown", {
+  expect_warning(p <- p <- if2_parameter("a", 0.1, min = 0, max = 1,
+                                         discrete = TRUE),
+                 "'discrete' is deprecated.\nUse 'integer' instead.")
+  expect_s3_class(p, "if2_parameter")
+  expect_equal(p$integer, TRUE)
 })
 
 
@@ -52,6 +61,7 @@ test_that("can construct and walk a set of parameters", {
                data_frame(name = c("beta", "gamma", "time"),
                           min = c(0.1, 0, -Inf),
                           max = c(2, 1, Inf),
+                          discrete = c(FALSE, FALSE, TRUE),
                           integer = c(FALSE, FALSE, TRUE)))
 
   n_pars <- length(pars$names())

--- a/tests/testthat/test-pmcmc-parameters-nested.R
+++ b/tests/testthat/test-pmcmc-parameters-nested.R
@@ -1,5 +1,5 @@
 test_that("Can construct a varied parameter", {
-  p <- pmcmc_varied_parameter("p1", letters[1:2], 1:2)
+  p <- pmcmc_varied_parameter("p1", letters[1:2], 1:2, integer = TRUE)
   expect_s3_class(p, "pmcmc_varied_parameter")
   expect_equal(p$a$name, "p1")
   expect_equal(p$b$name, "p1")
@@ -9,11 +9,21 @@ test_that("Can construct a varied parameter", {
   expect_equal(p$b$min, -Inf)
   expect_equal(p$a$max, Inf)
   expect_equal(p$b$max, Inf)
-  expect_equal(p$a$integer, FALSE)
-  expect_equal(p$b$integer, FALSE)
+  expect_equal(p$a$integer, TRUE)
+  expect_equal(p$b$integer, TRUE)
   expect_equal(p$a$prior(1), 0)
   expect_equal(p$b$prior(1), 0)
 })
+
+
+test_that("Can use 'discrete' argument but deprecation warning is shown", {
+  expect_warning(p <- pmcmc_varied_parameter("p1", letters[1:2], 1:2,
+                                             discrete = TRUE),
+                 "'discrete' is deprecated.\nUse 'integer' instead.")
+  expect_s3_class(p, "pmcmc_varied_parameter")
+  expect_equal(p$a$integer, TRUE)
+})
+
 
 test_that("varied parameter reps", {
   expect_equal(pmcmc_varied_parameter("p1", letters[1:3], 1)$c$initial, 1)
@@ -210,7 +220,7 @@ test_that("construct pmcmc_parameters_nested; contruction and basic use", {
   expect_equal(
     res$summary(),
     data_frame(name = rep(letters[1:4], 2),
-               min = -Inf, max = Inf, integer = FALSE,
+               min = -Inf, max = Inf, discrete = FALSE, integer = FALSE,
                type = rep(c("varied", "fixed"), each = 2),
                population = rep(c("p1", "p2"), each = 4)))
 })

--- a/tests/testthat/test-pmcmc-parameters-nested.R
+++ b/tests/testthat/test-pmcmc-parameters-nested.R
@@ -9,8 +9,8 @@ test_that("Can construct a varied parameter", {
   expect_equal(p$b$min, -Inf)
   expect_equal(p$a$max, Inf)
   expect_equal(p$b$max, Inf)
-  expect_equal(p$a$discrete, FALSE)
-  expect_equal(p$b$discrete, FALSE)
+  expect_equal(p$a$integer, FALSE)
+  expect_equal(p$b$integer, FALSE)
   expect_equal(p$a$prior(1), 0)
   expect_equal(p$b$prior(1), 0)
 })
@@ -22,7 +22,7 @@ test_that("varied parameter reps", {
   expect_equal(
     pmcmc_varied_parameter("p1", letters[1:3], 1, max = 1)$c$max, 1)
   expect_true(
-    pmcmc_varied_parameter("p1", letters[1:3], 1, discrete = TRUE)$c$discrete)
+    pmcmc_varied_parameter("p1", letters[1:3], 1, integer = TRUE)$c$integer)
   expect_equal(
     pmcmc_varied_parameter("p1", letters[1:3], 1,
                            prior = function(x) 1)$c$prior,
@@ -210,7 +210,7 @@ test_that("construct pmcmc_parameters_nested; contruction and basic use", {
   expect_equal(
     res$summary(),
     data_frame(name = rep(letters[1:4], 2),
-               min = -Inf, max = Inf, discrete = FALSE,
+               min = -Inf, max = Inf, integer = FALSE,
                type = rep(c("varied", "fixed"), each = 2),
                population = rep(c("p1", "p2"), each = 4)))
 })

--- a/tests/testthat/test-pmcmc-parameters.R
+++ b/tests/testthat/test-pmcmc-parameters.R
@@ -12,6 +12,15 @@ test_that("Can construct a parameter", {
 })
 
 
+test_that("Can use 'discrete' argument but deprecation warning is shown", {
+  expect_warning(p <- pmcmc_parameter("a", 1, 0, 10,
+                                      discrete = TRUE),
+                 "'discrete' is deprecated.\nUse 'integer' instead.")
+  expect_s3_class(p, "pmcmc_parameter")
+  expect_true(p$integer)
+})
+
+
 test_that("Can provide a prior", {
   f <- function(p) log(1 / p)
   p <- pmcmc_parameter("a", 1, prior = f)
@@ -209,7 +218,8 @@ test_that("can summarise parameters", {
   expect_equal(p$names(), c("beta", "gamma"))
   expect_equal(
     p$summary(),
-    data_frame(name = c("beta", "gamma"), min = 0, max = 1, integer = FALSE))
+    data_frame(name = c("beta", "gamma"), min = 0, max = 1, discrete = FALSE,
+               integer = FALSE))
 })
 
 

--- a/tests/testthat/test-pmcmc-parameters.R
+++ b/tests/testthat/test-pmcmc-parameters.R
@@ -7,7 +7,7 @@ test_that("Can construct a parameter", {
   expect_equal(p$initial, 1)
   expect_equal(p$min, 0)
   expect_equal(p$max, 10)
-  expect_false(p$discrete)
+  expect_false(p$integer)
   expect_equal(p$prior(1), 0)
 })
 
@@ -209,7 +209,7 @@ test_that("can summarise parameters", {
   expect_equal(p$names(), c("beta", "gamma"))
   expect_equal(
     p$summary(),
-    data_frame(name = c("beta", "gamma"), min = 0, max = 1, discrete = FALSE))
+    data_frame(name = c("beta", "gamma"), min = 0, max = 1, integer = FALSE))
 })
 
 

--- a/tests/testthat/test-smc2-parameters.R
+++ b/tests/testthat/test-smc2-parameters.R
@@ -7,18 +7,29 @@ test_that("can construct a parameter", {
   p <- smc2_parameter("a",
                      function(n) runif(n, 0, 10),
                      function(x) dunif(x, 0, 10, log = TRUE),
-                     min = 0, max = 10)
+                     min = 0, max = 10, integer = TRUE)
 
   expect_s3_class(p, "smc2_parameter")
   expect_equal(p$name, "a")
   expect_equal(p$min, 0)
   expect_equal(p$max, 10)
-  expect_false(p$integer)
+  expect_true(p$integer)
   expect_equal(p$prior(1), log(0.1))
   set.seed(1)
   res <- p$sample(20)
   set.seed(1)
   expect_equal(res, runif(20, 0, 10))
+})
+
+
+test_that("Can use 'discrete' argument but deprecation warning is shown", {
+  expect_warning(p <- smc2_parameter("a",
+                                     function(n) runif(n, 0, 10),
+                                     function(x) dunif(x, 0, 10, log = TRUE),
+                                     min = 0, max = 10, discrete = TRUE),
+                 "'discrete' is deprecated.\nUse 'integer' instead.")
+  expect_s3_class(p, "smc2_parameter")
+  expect_equal(p$integer, TRUE)
 })
 
 
@@ -50,6 +61,7 @@ test_that("can construct a set of parameters", {
                data_frame(name = c("beta", "gamma"),
                           min = c(0, 1),
                           max = c(10, 2),
+                          discrete = FALSE,
                           integer = FALSE))
 })
 

--- a/tests/testthat/test-smc2-parameters.R
+++ b/tests/testthat/test-smc2-parameters.R
@@ -13,7 +13,7 @@ test_that("can construct a parameter", {
   expect_equal(p$name, "a")
   expect_equal(p$min, 0)
   expect_equal(p$max, 10)
-  expect_false(p$discrete)
+  expect_false(p$integer)
   expect_equal(p$prior(1), log(0.1))
   set.seed(1)
   res <- p$sample(20)
@@ -50,7 +50,7 @@ test_that("can construct a set of parameters", {
                data_frame(name = c("beta", "gamma"),
                           min = c(0, 1),
                           max = c(10, 2),
-                          discrete = FALSE))
+                          integer = FALSE))
 })
 
 


### PR DESCRIPTION
Ahead of adding parameter checks in #175, rename "discrete" to "integer", leaving the deprecated argument name in place for backwards compatibility.