### PR TITLE
Return statistics from ode models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.9.7
+Version: 0.9.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -427,6 +427,23 @@ particle_filter <- R6::R6Class(
     },
 
     ##' @description
+    ##' Fetch statistics about steps taken during the integration, by
+    ##' calling through to the `$statistics()` method of the underlying
+    ##' model. This is only available for continuous time (ODE) models,
+    ##' and will error if used with discrete time models.
+    statistics = function() {
+      if (!inherits(private$data, "particle_filter_data_continuous")) {
+        stop("Statistics are only available for continuous (ODE) models")
+      }
+      if (is.null(private$last_model)) {
+        stop("Model has not yet been run")
+      }
+      ## when/if we support multistage models, more care will be
+      ## needed here.
+      private$last_model[[1]]$statistics()
+    },
+
+    ##' @description
     ##' Return the full particle filter state at points back in time
     ##' that were saved with the `save_restart` argument to
     ##' `$run()`. If available, this will return a 3d array, with

--- a/R/particle_filter_data.R
+++ b/R/particle_filter_data.R
@@ -136,6 +136,9 @@ particle_filter_data <- function(data, time, rate, initial_time = NULL,
   times <- cbind(time_start, time_end, deparse.level = 0)
   if (is_continuous) {
     steps <- NULL
+    time_start <- as.numeric(time_start)
+    time_end <- as.numeric(time_end)
+    storage.mode(times) <- "numeric"
     ret <- data.frame(time_start = time_start,
                       time_end = time_end,
                       time_start = time_start,

--- a/man/if2_parameters.Rd
+++ b/man/if2_parameters.Rd
@@ -43,19 +43,19 @@ pars$model(p_mat)
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{if2_parameters$new()}}
-\item \href{#method-initial}{\code{if2_parameters$initial()}}
-\item \href{#method-walk_initialise}{\code{if2_parameters$walk_initialise()}}
-\item \href{#method-walk}{\code{if2_parameters$walk()}}
-\item \href{#method-names}{\code{if2_parameters$names()}}
-\item \href{#method-summary}{\code{if2_parameters$summary()}}
-\item \href{#method-prior}{\code{if2_parameters$prior()}}
-\item \href{#method-model}{\code{if2_parameters$model()}}
+\item \href{#method-if2_parameters-new}{\code{if2_parameters$new()}}
+\item \href{#method-if2_parameters-initial}{\code{if2_parameters$initial()}}
+\item \href{#method-if2_parameters-walk_initialise}{\code{if2_parameters$walk_initialise()}}
+\item \href{#method-if2_parameters-walk}{\code{if2_parameters$walk()}}
+\item \href{#method-if2_parameters-names}{\code{if2_parameters$names()}}
+\item \href{#method-if2_parameters-summary}{\code{if2_parameters$summary()}}
+\item \href{#method-if2_parameters-prior}{\code{if2_parameters$prior()}}
+\item \href{#method-if2_parameters-model}{\code{if2_parameters$model()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-if2_parameters-new"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-new}{}}}
 \subsection{Method \code{new()}}{
 Create the if2_parameters object
 \subsection{Usage}{
@@ -82,8 +82,8 @@ you can do arbitrary transformations here.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-initial"></a>}}
-\if{latex}{\out{\hypertarget{method-initial}{}}}
+\if{html}{\out{<a id="method-if2_parameters-initial"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-initial}{}}}
 \subsection{Method \code{initial()}}{
 Return the initial parameter values as a named numeric
 vector
@@ -93,8 +93,8 @@ vector
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-walk_initialise"></a>}}
-\if{latex}{\out{\hypertarget{method-walk_initialise}{}}}
+\if{html}{\out{<a id="method-if2_parameters-walk_initialise"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-walk_initialise}{}}}
 \subsection{Method \code{walk_initialise()}}{
 Set up a parameter walk
 \subsection{Usage}{
@@ -114,8 +114,8 @@ of each parameter}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-walk"></a>}}
-\if{latex}{\out{\hypertarget{method-walk}{}}}
+\if{html}{\out{<a id="method-if2_parameters-walk"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-walk}{}}}
 \subsection{Method \code{walk()}}{
 Propose a new parameter matrix given a current matrix
 and walk standard deviation vector.
@@ -136,8 +136,8 @@ of each parameter}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-names"></a>}}
-\if{latex}{\out{\hypertarget{method-names}{}}}
+\if{html}{\out{<a id="method-if2_parameters-names"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-names}{}}}
 \subsection{Method \code{names()}}{
 Return the names of the parameters
 \subsection{Usage}{
@@ -146,8 +146,8 @@ Return the names of the parameters
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-summary"></a>}}
-\if{latex}{\out{\hypertarget{method-summary}{}}}
+\if{html}{\out{<a id="method-if2_parameters-summary"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{\link{data.frame}} with information about
 parameters (name, min, max, and integer).
@@ -157,8 +157,8 @@ parameters (name, min, max, and integer).
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-prior"></a>}}
-\if{latex}{\out{\hypertarget{method-prior}{}}}
+\if{html}{\out{<a id="method-if2_parameters-prior"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-prior}{}}}
 \subsection{Method \code{prior()}}{
 Compute the prior for a parameter vector
 \subsection{Usage}{
@@ -174,8 +174,8 @@ Compute the prior for a parameter vector
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-model"></a>}}
-\if{latex}{\out{\hypertarget{method-model}{}}}
+\if{html}{\out{<a id="method-if2_parameters-model"></a>}}
+\if{latex}{\out{\hypertarget{method-if2_parameters-model}{}}}
 \subsection{Method \code{model()}}{
 Apply the model transformation function to a parameter
 vector. Output is a list for lists, suitable for use with a dust

--- a/man/particle_deterministic.Rd
+++ b/man/particle_deterministic.Rd
@@ -39,19 +39,19 @@ particle (read only).  This will either be 1 or the same value as
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{particle_deterministic$new()}}
-\item \href{#method-run}{\code{particle_deterministic$run()}}
-\item \href{#method-run_begin}{\code{particle_deterministic$run_begin()}}
-\item \href{#method-state}{\code{particle_deterministic$state()}}
-\item \href{#method-history}{\code{particle_deterministic$history()}}
-\item \href{#method-restart_state}{\code{particle_deterministic$restart_state()}}
-\item \href{#method-inputs}{\code{particle_deterministic$inputs()}}
-\item \href{#method-set_n_threads}{\code{particle_deterministic$set_n_threads()}}
+\item \href{#method-particle_deterministic-new}{\code{particle_deterministic$new()}}
+\item \href{#method-particle_deterministic-run}{\code{particle_deterministic$run()}}
+\item \href{#method-particle_deterministic-run_begin}{\code{particle_deterministic$run_begin()}}
+\item \href{#method-particle_deterministic-state}{\code{particle_deterministic$state()}}
+\item \href{#method-particle_deterministic-history}{\code{particle_deterministic$history()}}
+\item \href{#method-particle_deterministic-restart_state}{\code{particle_deterministic$restart_state()}}
+\item \href{#method-particle_deterministic-inputs}{\code{particle_deterministic$inputs()}}
+\item \href{#method-particle_deterministic-set_n_threads}{\code{particle_deterministic$set_n_threads()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-new"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-new}{}}}
 \subsection{Method \code{new()}}{
 Create the particle filter
 \subsection{Usage}{
@@ -146,8 +146,8 @@ most outputs (scalars become vectors, vectors become matrices etc).}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-run"></a>}}
-\if{latex}{\out{\hypertarget{method-run}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-run"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-run}{}}}
 \subsection{Method \code{run()}}{
 Run the deterministic particle filter
 \subsection{Usage}{
@@ -191,8 +191,8 @@ A single numeric value representing the log-likelihood
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-run_begin"></a>}}
-\if{latex}{\out{\hypertarget{method-run_begin}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-run_begin"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-run_begin}{}}}
 \subsection{Method \code{run_begin()}}{
 Begin a deterministic run. This is part of the
 "advanced" interface; typically you will want to use \verb{$run()}
@@ -232,8 +232,8 @@ An object of class \code{particle_deterministic_state}, with methods
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-state"></a>}}
-\if{latex}{\out{\hypertarget{method-state}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-state"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-state}{}}}
 \subsection{Method \code{state()}}{
 Extract the current model state, optionally filtering.
 If the model has not yet been run, then this method will throw an
@@ -253,8 +253,8 @@ particles.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-history"></a>}}
-\if{latex}{\out{\hypertarget{method-history}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-history"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-history}{}}}
 \subsection{Method \code{history()}}{
 Extract the particle trajectories. Requires that
 the model was run with \code{save_history = TRUE}, which does
@@ -277,8 +277,8 @@ If \code{NULL} we return all particles' histories.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-restart_state"></a>}}
-\if{latex}{\out{\hypertarget{method-restart_state}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-restart_state"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-restart_state}{}}}
 \subsection{Method \code{restart_state()}}{
 Return the full particle filter state at points back in time
 that were saved with the \code{save_restart} argument to
@@ -310,8 +310,8 @@ interface.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-inputs"></a>}}
-\if{latex}{\out{\hypertarget{method-inputs}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-inputs"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-inputs}{}}}
 \subsection{Method \code{inputs()}}{
 Return a list of inputs used to configure the deterministic particle
 filter. These correspond directly to the argument names for the
@@ -322,8 +322,8 @@ constructor and are the same as the input arguments.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-set_n_threads"></a>}}
-\if{latex}{\out{\hypertarget{method-set_n_threads}{}}}
+\if{html}{\out{<a id="method-particle_deterministic-set_n_threads"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic-set_n_threads}{}}}
 \subsection{Method \code{set_n_threads()}}{
 Set the number of threads used by the particle filter (and dust
 model) after creation. This can be used to allocate additional

--- a/man/particle_deterministic_state.Rd
+++ b/man/particle_deterministic_state.Rd
@@ -36,15 +36,15 @@ This is a 3d array as described in \link{particle_filter}}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{particle_deterministic_state$new()}}
-\item \href{#method-run}{\code{particle_deterministic_state$run()}}
-\item \href{#method-step}{\code{particle_deterministic_state$step()}}
-\item \href{#method-fork_multistage}{\code{particle_deterministic_state$fork_multistage()}}
+\item \href{#method-particle_deterministic_state-new}{\code{particle_deterministic_state$new()}}
+\item \href{#method-particle_deterministic_state-run}{\code{particle_deterministic_state$run()}}
+\item \href{#method-particle_deterministic_state-step}{\code{particle_deterministic_state$step()}}
+\item \href{#method-particle_deterministic_state-fork_multistage}{\code{particle_deterministic_state$fork_multistage()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-particle_deterministic_state-new"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic_state-new}{}}}
 \subsection{Method \code{new()}}{
 Initialise the deterministic particle state. Ordinarily
 this should not be called by users, and so arguments are barely
@@ -103,8 +103,8 @@ documented.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-run"></a>}}
-\if{latex}{\out{\hypertarget{method-run}{}}}
+\if{html}{\out{<a id="method-particle_deterministic_state-run"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic_state-run}{}}}
 \subsection{Method \code{run()}}{
 Run the deterministic particle to the end of the data.
 This is a convenience function around \verb{$step()} which provides the
@@ -115,8 +115,8 @@ correct value of \code{step_index}
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-step"></a>}}
-\if{latex}{\out{\hypertarget{method-step}{}}}
+\if{html}{\out{<a id="method-particle_deterministic_state-step"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic_state-step}{}}}
 \subsection{Method \code{step()}}{
 Take a step with the deterministic particle. This moves
 the system forward one step within the \emph{data} (which
@@ -139,8 +139,8 @@ the end of the data.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fork_multistage"></a>}}
-\if{latex}{\out{\hypertarget{method-fork_multistage}{}}}
+\if{html}{\out{<a id="method-particle_deterministic_state-fork_multistage"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_deterministic_state-fork_multistage}{}}}
 \subsection{Method \code{fork_multistage()}}{
 Create a new \code{deterministic_particle_state} object based
 on this one (same model, position in time within the data) but with

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -93,19 +93,20 @@ this will be 1.}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{particle_filter$new()}}
-\item \href{#method-run}{\code{particle_filter$run()}}
-\item \href{#method-run_begin}{\code{particle_filter$run_begin()}}
-\item \href{#method-state}{\code{particle_filter$state()}}
-\item \href{#method-history}{\code{particle_filter$history()}}
-\item \href{#method-restart_state}{\code{particle_filter$restart_state()}}
-\item \href{#method-inputs}{\code{particle_filter$inputs()}}
-\item \href{#method-set_n_threads}{\code{particle_filter$set_n_threads()}}
+\item \href{#method-particle_filter-new}{\code{particle_filter$new()}}
+\item \href{#method-particle_filter-run}{\code{particle_filter$run()}}
+\item \href{#method-particle_filter-run_begin}{\code{particle_filter$run_begin()}}
+\item \href{#method-particle_filter-state}{\code{particle_filter$state()}}
+\item \href{#method-particle_filter-history}{\code{particle_filter$history()}}
+\item \href{#method-particle_filter-statistics}{\code{particle_filter$statistics()}}
+\item \href{#method-particle_filter-restart_state}{\code{particle_filter$restart_state()}}
+\item \href{#method-particle_filter-inputs}{\code{particle_filter$inputs()}}
+\item \href{#method-particle_filter-set_n_threads}{\code{particle_filter$set_n_threads()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-particle_filter-new"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-new}{}}}
 \subsection{Method \code{new()}}{
 Create the particle filter
 \subsection{Usage}{
@@ -230,8 +231,8 @@ list will be added in a future version!}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-run"></a>}}
-\if{latex}{\out{\hypertarget{method-run}{}}}
+\if{html}{\out{<a id="method-particle_filter-run"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-run}{}}}
 \subsection{Method \code{run()}}{
 Run the particle filter
 \subsection{Usage}{
@@ -289,8 +290,8 @@ A single numeric value representing the log-likelihood
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-run_begin"></a>}}
-\if{latex}{\out{\hypertarget{method-run_begin}{}}}
+\if{html}{\out{<a id="method-particle_filter-run_begin"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-run_begin}{}}}
 \subsection{Method \code{run_begin()}}{
 Begin a particle filter run. This is part of the
 "advanced" interface for the particle filter; typically you will
@@ -328,8 +329,8 @@ An object of class \code{particle_filter_state}, with methods
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-state"></a>}}
-\if{latex}{\out{\hypertarget{method-state}{}}}
+\if{html}{\out{<a id="method-particle_filter-state"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-state}{}}}
 \subsection{Method \code{state()}}{
 Extract the current model state, optionally filtering.
 If the model has not yet been run, then this method will throw an
@@ -349,8 +350,8 @@ particles.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-history"></a>}}
-\if{latex}{\out{\hypertarget{method-history}{}}}
+\if{html}{\out{<a id="method-particle_filter-history"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-history}{}}}
 \subsection{Method \code{history()}}{
 Extract the particle trajectories. Requires that
 the model was run with \code{save_history = TRUE}, which does
@@ -378,8 +379,21 @@ histories.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-restart_state"></a>}}
-\if{latex}{\out{\hypertarget{method-restart_state}{}}}
+\if{html}{\out{<a id="method-particle_filter-statistics"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-statistics}{}}}
+\subsection{Method \code{statistics()}}{
+Fetch statistics about steps taken during the integration, by
+calling through to the \verb{$statistics()} method of the underlying
+model. This is only available for continuous time (ODE) models,
+and will error if used with discrete time models.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$statistics()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-particle_filter-restart_state"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-restart_state}{}}}
 \subsection{Method \code{restart_state()}}{
 Return the full particle filter state at points back in time
 that were saved with the \code{save_restart} argument to
@@ -411,8 +425,8 @@ If \code{NULL} we return all particles' states.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-inputs"></a>}}
-\if{latex}{\out{\hypertarget{method-inputs}{}}}
+\if{html}{\out{<a id="method-particle_filter-inputs"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-inputs}{}}}
 \subsection{Method \code{inputs()}}{
 Return a list of inputs used to configure the particle
 filter. These correspond directly to the argument names for the
@@ -426,8 +440,8 @@ restart the model).
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-set_n_threads"></a>}}
-\if{latex}{\out{\hypertarget{method-set_n_threads}{}}}
+\if{html}{\out{<a id="method-particle_filter-set_n_threads"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-set_n_threads}{}}}
 \subsection{Method \code{set_n_threads()}}{
 Set the number of threads used by the particle filter (and dust
 model) after creation. This can be used to allocate additional

--- a/man/particle_filter_state.Rd
+++ b/man/particle_filter_state.Rd
@@ -42,16 +42,16 @@ last call to \verb{$step()}.}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{particle_filter_state$new()}}
-\item \href{#method-run}{\code{particle_filter_state$run()}}
-\item \href{#method-step}{\code{particle_filter_state$step()}}
-\item \href{#method-fork_multistage}{\code{particle_filter_state$fork_multistage()}}
-\item \href{#method-fork_smc2}{\code{particle_filter_state$fork_smc2()}}
+\item \href{#method-particle_filter_state-new}{\code{particle_filter_state$new()}}
+\item \href{#method-particle_filter_state-run}{\code{particle_filter_state$run()}}
+\item \href{#method-particle_filter_state-step}{\code{particle_filter_state$step()}}
+\item \href{#method-particle_filter_state-fork_multistage}{\code{particle_filter_state$fork_multistage()}}
+\item \href{#method-particle_filter_state-fork_smc2}{\code{particle_filter_state$fork_smc2()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-particle_filter_state-new"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter_state-new}{}}}
 \subsection{Method \code{new()}}{
 Initialise the particle filter state. Ordinarily
 this should not be called by users, and so arguments are barely
@@ -128,8 +128,8 @@ documented.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-run"></a>}}
-\if{latex}{\out{\hypertarget{method-run}{}}}
+\if{html}{\out{<a id="method-particle_filter_state-run"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter_state-run}{}}}
 \subsection{Method \code{run()}}{
 Run the particle filter to the end of the data. This is
 a convenience function around \verb{$step()} which provides the correct
@@ -140,8 +140,8 @@ value of \code{step_index}
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-step"></a>}}
-\if{latex}{\out{\hypertarget{method-step}{}}}
+\if{html}{\out{<a id="method-particle_filter_state-step"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter_state-step}{}}}
 \subsection{Method \code{step()}}{
 Take a step with the particle filter. This moves
 the particle filter forward one step within the \emph{data} (which
@@ -167,8 +167,8 @@ likelihood, due to this step, rather than the full likelihood so far.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fork_multistage"></a>}}
-\if{latex}{\out{\hypertarget{method-fork_multistage}{}}}
+\if{html}{\out{<a id="method-particle_filter_state-fork_multistage"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter_state-fork_multistage}{}}}
 \subsection{Method \code{fork_multistage()}}{
 Create a new \code{particle_filter_state} object based on
 this one (same model, position in time within the data) but with
@@ -196,8 +196,8 @@ from the old to the new parameter set.  See
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fork_smc2"></a>}}
-\if{latex}{\out{\hypertarget{method-fork_smc2}{}}}
+\if{html}{\out{<a id="method-particle_filter_state-fork_smc2"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter_state-fork_smc2}{}}}
 \subsection{Method \code{fork_smc2()}}{
 Create a new \code{particle_filter_state} object based
 on this one (same model, position in time within the data) but

--- a/man/pmcmc_chains.Rd
+++ b/man/pmcmc_chains.Rd
@@ -51,13 +51,15 @@ execution of the chains yourself. Use this if you want to
 distribute chains over (say) the nodes of an HPC system.
 }
 \details{
-Basic usage will look like\preformatted{path <- mcstate::pmcmc_chains_prepare(tempfile(), pars, filter, control)
+Basic usage will look like
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{path <- mcstate::pmcmc_chains_prepare(tempfile(), pars, filter, control)
 for (i in seq_len(control$n_chains)) \{
   mcstate::pmcmc_chains_run(i, path)
 \}
 samples <- mcstate::pmcmc_chains_collect(path)
 mcstate::pmcmc_chains_cleanup(path)
-}
+}\if{html}{\out{</div>}}
 
 You can safely parallelise (or not) however you like at the point
 where the loop is (even across other machines) and get the same

--- a/man/pmcmc_parameters.Rd
+++ b/man/pmcmc_parameters.Rd
@@ -38,21 +38,21 @@ pars$model(p)
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{pmcmc_parameters$new()}}
-\item \href{#method-initial}{\code{pmcmc_parameters$initial()}}
-\item \href{#method-mean}{\code{pmcmc_parameters$mean()}}
-\item \href{#method-vcv}{\code{pmcmc_parameters$vcv()}}
-\item \href{#method-names}{\code{pmcmc_parameters$names()}}
-\item \href{#method-summary}{\code{pmcmc_parameters$summary()}}
-\item \href{#method-prior}{\code{pmcmc_parameters$prior()}}
-\item \href{#method-propose}{\code{pmcmc_parameters$propose()}}
-\item \href{#method-model}{\code{pmcmc_parameters$model()}}
-\item \href{#method-fix}{\code{pmcmc_parameters$fix()}}
+\item \href{#method-pmcmc_parameters-new}{\code{pmcmc_parameters$new()}}
+\item \href{#method-pmcmc_parameters-initial}{\code{pmcmc_parameters$initial()}}
+\item \href{#method-pmcmc_parameters-mean}{\code{pmcmc_parameters$mean()}}
+\item \href{#method-pmcmc_parameters-vcv}{\code{pmcmc_parameters$vcv()}}
+\item \href{#method-pmcmc_parameters-names}{\code{pmcmc_parameters$names()}}
+\item \href{#method-pmcmc_parameters-summary}{\code{pmcmc_parameters$summary()}}
+\item \href{#method-pmcmc_parameters-prior}{\code{pmcmc_parameters$prior()}}
+\item \href{#method-pmcmc_parameters-propose}{\code{pmcmc_parameters$propose()}}
+\item \href{#method-pmcmc_parameters-model}{\code{pmcmc_parameters$model()}}
+\item \href{#method-pmcmc_parameters-fix}{\code{pmcmc_parameters$fix()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-new"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-new}{}}}
 \subsection{Method \code{new()}}{
 Create the pmcmc_parameters object
 \subsection{Usage}{
@@ -87,8 +87,8 @@ you can do arbitrary transformations here.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-initial"></a>}}
-\if{latex}{\out{\hypertarget{method-initial}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-initial"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-initial}{}}}
 \subsection{Method \code{initial()}}{
 Return the initial parameter values as a named numeric
 vector
@@ -98,8 +98,8 @@ vector
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-mean"></a>}}
-\if{latex}{\out{\hypertarget{method-mean}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-mean"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-mean}{}}}
 \subsection{Method \code{mean()}}{
 Return the estimate of the mean of the parameters,
 as set when created (this is not updated by any fitting!)
@@ -109,8 +109,8 @@ as set when created (this is not updated by any fitting!)
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-vcv"></a>}}
-\if{latex}{\out{\hypertarget{method-vcv}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-vcv"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-vcv}{}}}
 \subsection{Method \code{vcv()}}{
 Return the variance-covariance matrix used for the
 proposal.
@@ -120,8 +120,8 @@ proposal.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-names"></a>}}
-\if{latex}{\out{\hypertarget{method-names}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-names"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-names}{}}}
 \subsection{Method \code{names()}}{
 Return the names of the parameters
 \subsection{Usage}{
@@ -130,8 +130,8 @@ Return the names of the parameters
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-summary"></a>}}
-\if{latex}{\out{\hypertarget{method-summary}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-summary"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{data.frame} with information about
 parameters (name, min, max, and integer).
@@ -141,8 +141,8 @@ parameters (name, min, max, and integer).
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-prior"></a>}}
-\if{latex}{\out{\hypertarget{method-prior}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-prior"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-prior}{}}}
 \subsection{Method \code{prior()}}{
 Compute the prior for a parameter vector
 \subsection{Usage}{
@@ -159,8 +159,8 @@ parameters were defined in (see \verb{$names()} for that order.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-propose"></a>}}
-\if{latex}{\out{\hypertarget{method-propose}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-propose"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-propose}{}}}
 \subsection{Method \code{propose()}}{
 Propose a new parameter vector given a current parameter
 vector. This proposes a new parameter vector given your current
@@ -191,8 +191,8 @@ matrix to be used (e.g., during an adaptive MCMC)}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-model"></a>}}
-\if{latex}{\out{\hypertarget{method-model}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-model"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-model}{}}}
 \subsection{Method \code{model()}}{
 Apply the model transformation function to a parameter
 vector.
@@ -210,8 +210,8 @@ parameters were defined in (see \verb{$names()} for that order.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fix"></a>}}
-\if{latex}{\out{\hypertarget{method-fix}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters-fix"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters-fix}{}}}
 \subsection{Method \code{fix()}}{
 Set some parameters to fixed values. Use this to
 reduce the dimensionality of your system.

--- a/man/pmcmc_parameters_nested.Rd
+++ b/man/pmcmc_parameters_nested.Rd
@@ -47,21 +47,21 @@ pars$model(p)
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{pmcmc_parameters_nested$new()}}
-\item \href{#method-names}{\code{pmcmc_parameters_nested$names()}}
-\item \href{#method-populations}{\code{pmcmc_parameters_nested$populations()}}
-\item \href{#method-validate}{\code{pmcmc_parameters_nested$validate()}}
-\item \href{#method-summary}{\code{pmcmc_parameters_nested$summary()}}
-\item \href{#method-initial}{\code{pmcmc_parameters_nested$initial()}}
-\item \href{#method-prior}{\code{pmcmc_parameters_nested$prior()}}
-\item \href{#method-propose}{\code{pmcmc_parameters_nested$propose()}}
-\item \href{#method-model}{\code{pmcmc_parameters_nested$model()}}
-\item \href{#method-fix}{\code{pmcmc_parameters_nested$fix()}}
+\item \href{#method-pmcmc_parameters_nested-new}{\code{pmcmc_parameters_nested$new()}}
+\item \href{#method-pmcmc_parameters_nested-names}{\code{pmcmc_parameters_nested$names()}}
+\item \href{#method-pmcmc_parameters_nested-populations}{\code{pmcmc_parameters_nested$populations()}}
+\item \href{#method-pmcmc_parameters_nested-validate}{\code{pmcmc_parameters_nested$validate()}}
+\item \href{#method-pmcmc_parameters_nested-summary}{\code{pmcmc_parameters_nested$summary()}}
+\item \href{#method-pmcmc_parameters_nested-initial}{\code{pmcmc_parameters_nested$initial()}}
+\item \href{#method-pmcmc_parameters_nested-prior}{\code{pmcmc_parameters_nested$prior()}}
+\item \href{#method-pmcmc_parameters_nested-propose}{\code{pmcmc_parameters_nested$propose()}}
+\item \href{#method-pmcmc_parameters_nested-model}{\code{pmcmc_parameters_nested$model()}}
+\item \href{#method-pmcmc_parameters_nested-fix}{\code{pmcmc_parameters_nested$fix()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-new"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-new}{}}}
 \subsection{Method \code{new()}}{
 Create the pmcmc_parameters object
 \subsection{Usage}{
@@ -108,8 +108,8 @@ you can do arbitrary transformations here.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-names"></a>}}
-\if{latex}{\out{\hypertarget{method-names}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-names"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-names}{}}}
 \subsection{Method \code{names()}}{
 Return the names of the parameters
 \subsection{Usage}{
@@ -127,8 +127,8 @@ Return the names of the parameters
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-populations"></a>}}
-\if{latex}{\out{\hypertarget{method-populations}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-populations"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-populations}{}}}
 \subsection{Method \code{populations()}}{
 Return the names of the populations
 \subsection{Usage}{
@@ -137,8 +137,8 @@ Return the names of the populations
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validate"></a>}}
-\if{latex}{\out{\hypertarget{method-validate}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-validate"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-validate}{}}}
 \subsection{Method \code{validate()}}{
 Validate a parameter matrix.  This method
 checks that your matrix has the expected size (rows according
@@ -158,8 +158,8 @@ fixed parameters are same across all populations.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-summary"></a>}}
-\if{latex}{\out{\hypertarget{method-summary}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-summary"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{data.frame} with information about
 parameters (name, min, max, integer, type (fixed or varied)
@@ -170,8 +170,8 @@ and population)
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-initial"></a>}}
-\if{latex}{\out{\hypertarget{method-initial}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-initial"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-initial}{}}}
 \subsection{Method \code{initial()}}{
 Return the initial parameter values as a named matrix with
 rows corresponding to parameters and columns to populations.
@@ -181,8 +181,8 @@ rows corresponding to parameters and columns to populations.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-prior"></a>}}
-\if{latex}{\out{\hypertarget{method-prior}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-prior"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-prior}{}}}
 \subsection{Method \code{prior()}}{
 Compute the prior(s) for a parameter matrix. Returns a
 named vector with names corresponding to populations.
@@ -200,8 +200,8 @@ named vector with names corresponding to populations.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-propose"></a>}}
-\if{latex}{\out{\hypertarget{method-propose}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-propose"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-propose}{}}}
 \subsection{Method \code{propose()}}{
 This proposes a new parameter matrix given your current
 matrix and the variance-covariance matrices of the proposal
@@ -233,8 +233,8 @@ applied to the variance covariance matrix.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-model"></a>}}
-\if{latex}{\out{\hypertarget{method-model}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-model"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-model}{}}}
 \subsection{Method \code{model()}}{
 Apply the model transformation function to a parameter
 matrix.
@@ -252,8 +252,8 @@ matrix.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fix"></a>}}
-\if{latex}{\out{\hypertarget{method-fix}{}}}
+\if{html}{\out{<a id="method-pmcmc_parameters_nested-fix"></a>}}
+\if{latex}{\out{\hypertarget{method-pmcmc_parameters_nested-fix}{}}}
 \subsection{Method \code{fix()}}{
 Set some parameters to fixed values. Use this to
 reduce the dimensionality of your system.  Note that this function

--- a/man/smc2_parameters.Rd
+++ b/man/smc2_parameters.Rd
@@ -13,18 +13,18 @@ used.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{smc2_parameters$new()}}
-\item \href{#method-sample}{\code{smc2_parameters$sample()}}
-\item \href{#method-names}{\code{smc2_parameters$names()}}
-\item \href{#method-summary}{\code{smc2_parameters$summary()}}
-\item \href{#method-prior}{\code{smc2_parameters$prior()}}
-\item \href{#method-propose}{\code{smc2_parameters$propose()}}
-\item \href{#method-model}{\code{smc2_parameters$model()}}
+\item \href{#method-smc2_parameters-new}{\code{smc2_parameters$new()}}
+\item \href{#method-smc2_parameters-sample}{\code{smc2_parameters$sample()}}
+\item \href{#method-smc2_parameters-names}{\code{smc2_parameters$names()}}
+\item \href{#method-smc2_parameters-summary}{\code{smc2_parameters$summary()}}
+\item \href{#method-smc2_parameters-prior}{\code{smc2_parameters$prior()}}
+\item \href{#method-smc2_parameters-propose}{\code{smc2_parameters$propose()}}
+\item \href{#method-smc2_parameters-model}{\code{smc2_parameters$model()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-smc2_parameters-new"></a>}}
+\if{latex}{\out{\hypertarget{method-smc2_parameters-new}{}}}
 \subsection{Method \code{new()}}{
 Create the smc2_parameters object
 \subsection{Usage}{
@@ -51,8 +51,8 @@ you can do arbitrary transformations here.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-sample"></a>}}
-\if{latex}{\out{\hypertarget{method-sample}{}}}
+\if{html}{\out{<a id="method-smc2_parameters-sample"></a>}}
+\if{latex}{\out{\hypertarget{method-smc2_parameters-sample}{}}}
 \subsection{Method \code{sample()}}{
 Create \code{n} independent random parameter vectors (as a
 matrix with \code{n} rows)
@@ -69,8 +69,8 @@ matrix with \code{n} rows)
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-names"></a>}}
-\if{latex}{\out{\hypertarget{method-names}{}}}
+\if{html}{\out{<a id="method-smc2_parameters-names"></a>}}
+\if{latex}{\out{\hypertarget{method-smc2_parameters-names}{}}}
 \subsection{Method \code{names()}}{
 Return the names of the parameters
 \subsection{Usage}{
@@ -79,8 +79,8 @@ Return the names of the parameters
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-summary"></a>}}
-\if{latex}{\out{\hypertarget{method-summary}{}}}
+\if{html}{\out{<a id="method-smc2_parameters-summary"></a>}}
+\if{latex}{\out{\hypertarget{method-smc2_parameters-summary}{}}}
 \subsection{Method \code{summary()}}{
 Return a \code{data.frame} with information about
 parameters (name, min, max, and integer).
@@ -90,8 +90,8 @@ parameters (name, min, max, and integer).
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-prior"></a>}}
-\if{latex}{\out{\hypertarget{method-prior}{}}}
+\if{html}{\out{<a id="method-smc2_parameters-prior"></a>}}
+\if{latex}{\out{\hypertarget{method-smc2_parameters-prior}{}}}
 \subsection{Method \code{prior()}}{
 Compute the prior for a parameter vector
 \subsection{Usage}{
@@ -108,8 +108,8 @@ parameters were defined in (see \verb{$names()} for that order.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-propose"></a>}}
-\if{latex}{\out{\hypertarget{method-propose}{}}}
+\if{html}{\out{<a id="method-smc2_parameters-propose"></a>}}
+\if{latex}{\out{\hypertarget{method-smc2_parameters-propose}{}}}
 \subsection{Method \code{propose()}}{
 Propose a new parameter vector given a current parameter
 vector and variance covariance matrix. After proposal, this rounds
@@ -133,8 +133,8 @@ number of parameters, in the same order as \code{theta}.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-model"></a>}}
-\if{latex}{\out{\hypertarget{method-model}{}}}
+\if{html}{\out{<a id="method-smc2_parameters-model"></a>}}
+\if{latex}{\out{\hypertarget{method-smc2_parameters-model}{}}}
 \subsection{Method \code{model()}}{
 Apply the model transformation function to a parameter
 vector.

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -61,7 +61,7 @@ example_sir <- function() {
 }
 
 example_continuous <- function() {
-  model <- odin.dust::odin_dust("malaria/malariamodel.R", verbose = TRUE)
+  model <- odin.dust::odin_dust("malaria/malariamodel.R", verbose = FALSE)
 
   compare <- function(state, observed, pars = NULL) {
     dbinom(x = observed$positive,

--- a/tests/testthat/test-particle-filter-data.R
+++ b/tests/testthat/test-particle-filter-data.R
@@ -197,3 +197,11 @@ test_that("particle_filter_data for continuous time by month", {
   expect_equal(res$time_start, res$day_start)
   expect_equal(res$time_end, res$day_end)
 })
+
+test_that("particle_filter_data for continuous time requires initial time", {
+  d <- data.frame(month = 4:24,
+                  data = runif(21),
+                  stringsAsFactors = FALSE)
+  expect_error(particle_filter_data(d, "month", NULL),
+               "'initial_time' must be given for continuous models")
+})

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1508,6 +1508,7 @@ test_that("run particle filter on continuous model", {
                nrates = 15)
   res <- p$run(pars)
   expect_is(res, "numeric")
+  expect_false(res == p$run(pars))
 
   mod <- dat$model$new(pars, 0, 1, seed = 1L)
   len <- mod$info()$len

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1619,3 +1619,39 @@ test_that("continuous data given iff model is continuous", {
                            index = dat$index),
                e)
 })
+
+
+test_that("Can fetch statistics from continuous model", {
+  dat <- example_continuous()
+  n_particles <- 42
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index, seed = 1L,
+                           stochastic_schedule = dat$stochastic_schedule)
+  pars <- list(init_Ih = 0.8,
+               init_Sv = 100,
+               init_Iv = 1,
+               nrates = 15)
+  expect_error(p$statistics(),
+               "Model has not yet been run")
+  res <- p$run(pars)
+  s <- p$statistics()
+  expect_s3_class(s, "mode_statistics")
+})
+
+
+test_that("Can't fetch statistics from discrete model", {
+  dat <- example_sir()
+  n_particles <- 42
+  set.seed(1)
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index, seed = 1L)
+  expect_error(
+    p$statistics(),
+    "Statistics are only available for continuous (ODE) models",
+    fixed = TRUE)
+  res <- p$run()
+  expect_error(
+    p$statistics(),
+    "Statistics are only available for continuous (ODE) models",
+    fixed = TRUE)
+})


### PR DESCRIPTION
This PR exposes a `statistics()` method on the filter object, which returns statistics from the underlying model. Currently only valid for ode models and I am not sure that it would ever be useful on a discrete time model? We could call it `ode_statistics()` to reflect that or leave it generic and then if we change our mind it's there.

This does make me wonder if we should not be looking after the statistics for step in a similar way to state where we don't copy over - that's an issue for mode though as the interface won't change. But here we end up with the *filtered* set of steps which may not show us the particle that struggled a lot. Of course in the case with the malaria model they all struggle so it's probably ok

The second commit, 468a281, is not really related but fixes a bug while filling the remaining coverage holes (how can they hide in such small places?)