### PR TITLE
Tweaks to get continuous models working with pmcmc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.9.8
+Version: 0.9.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Suggests:
     fs,
     knitr,
     mockery,
-    mode (>= 0.1.6)
+    mode (>= 0.1.6),
     mvtnorm,
     odin.dust (>= 0.2.20),
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,9 @@ Suggests:
     fs,
     knitr,
     mockery,
+    mode (>= 0.1.6)
     mvtnorm,
-    odin.dust (>= 0.2.14),
+    odin.dust (>= 0.2.20),
     rmarkdown,
     testthat,
     withr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.9.9
+
+* Basic inference now working with continuous time (ODE) models, via `particle_filter` and `pmcmc`
+
 # mcstate 0.9.2
 
 * Support for adaptive proposals for deterministic models

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -540,6 +540,8 @@ particle_resample <- function(weights) {
 ## Private helper for reconstituting a particle filter from its
 ## `$inputs()` data, but possibly changing the seed
 particle_filter_from_inputs <- function(inputs, seed = NULL) {
+  ## TODO: this needs adjusting to work with continuous time
+  ## models. Then add test to show that all args are represented.
   if (is.null(inputs$n_particles)) {
     particle_deterministic$new(
       data = inputs$data,

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -540,8 +540,6 @@ particle_resample <- function(weights) {
 ## Private helper for reconstituting a particle filter from its
 ## `$inputs()` data, but possibly changing the seed
 particle_filter_from_inputs <- function(inputs, seed = NULL) {
-  ## TODO: this needs adjusting to work with continuous time
-  ## models. Then add test to show that all args are represented.
   if (is.null(inputs$n_particles)) {
     particle_deterministic$new(
       data = inputs$data,
@@ -562,7 +560,9 @@ particle_filter_from_inputs <- function(inputs, seed = NULL) {
       initial = inputs$initial,
       constant_log_likelihood = inputs$constant_log_likelihood,
       n_threads = inputs$n_threads,
-      seed = seed %||% inputs$seed)
+      seed = seed %||% inputs$seed,
+      stochastic_schedule = inputs$stochastic_schedule,
+      ode_control = inputs$ode_control)
   }
 }
 

--- a/R/pmcmc_state.R
+++ b/R/pmcmc_state.R
@@ -308,7 +308,7 @@ pmcmc_state <- R6::R6Class(
           rate <- NULL
           time <- last(data$time_end)
         } else {
-          step <- last(date$step_end)
+          step <- last(data$step_end)
           rate <- attr(data, "rate", exact = TRUE)
           time <- step * rate
         }

--- a/R/predict.R
+++ b/R/predict.R
@@ -78,10 +78,10 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   }
   y <- mod$simulate(steps)
 
-  res <- mcstate_trajectories(steps, object$predict$rate, y, TRUE)
+  res <- mcstate_trajectories_discrete(steps, object$predict$rate, y, TRUE)
 
   if (prepend_trajectories) {
-    res <- bind_mcstate_trajectories(object$trajectories, res)
+    res <- bind_mcstate_trajectories_discrete(object$trajectories, res)
   }
 
   res

--- a/R/predict.R
+++ b/R/predict.R
@@ -38,6 +38,9 @@ pmcmc_predict <- function(object, steps, prepend_trajectories = FALSE,
   if (is.null(object$predict)) {
     stop("mcmc was run with return_state = FALSE, can't predict")
   }
+  if (isTRUE(object$predict$is_continuous)) {
+    stop("predict not (yet) possible with continuous models (mrc-3453)")
+  }
   if (length(steps) < 2) {
     stop("At least two steps required for predict")
   }

--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -41,7 +41,7 @@ bind_mcstate_trajectories_discrete <- function(a, b) {
   rownames(state) <- rownames(b$state) %||% rownames(a$state)
   predicted <- c(a$predicted, b$predicted[-1])
 
-  mcstate_trajectories(step, a$rate, state, predicted)
+  mcstate_trajectories_discrete(step, a$rate, state, predicted)
 }
 
 

--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -14,7 +14,7 @@ mcstate_trajectories_discrete <- function(step, rate, state, predicted) {
 ## parallel class here.
 mcstate_trajectories_continuous <- function(time, state, predicted) {
   if (length(predicted) == 1L) {
-    predicted <- rep_len(predicted, length(step))
+    predicted <- rep_len(predicted, length(time))
   }
   if (any(predicted)) {
     stop("predicted continuous trajectories not supported (mrc-3452, mrc-3453)")

--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -17,7 +17,7 @@ mcstate_trajectories_continuous <- function(time, state, predicted) {
     predicted <- rep_len(predicted, length(step))
   }
   if (any(predicted)) {
-    stop("predicted trajectories not yet supported (mrc-3452, mrc-3453)")
+    stop("predicted continuous trajectories not supported (mrc-3452, mrc-3453)")
   }
   ret <- list(time = time, state = state, predicted = predicted)
   class(ret) <- c("mcstate_trajectories_continuous", "mcstate_trajectories")

--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -1,16 +1,33 @@
-mcstate_trajectories <- function(step, rate, state, predicted) {
+mcstate_trajectories_discrete <- function(step, rate, state, predicted) {
   if (length(predicted) == 1L) {
     predicted <- rep(predicted, length(step))
   }
   ret <- list(step = step, rate = rate, state = state, predicted = predicted)
-  class(ret) <- "mcstate_trajectories"
+  class(ret) <- c("mcstate_trajectories_discrete", "mcstate_trajectories")
   ret
 }
 
 
-bind_mcstate_trajectories <- function(a, b) {
-  stopifnot(inherits(a, "mcstate_trajectories"),
-            inherits(b, "mcstate_trajectories"),
+## There's some longer term tidying up this interface with the above,
+## but the time issue is pretty fundamental unfortunately. Because the
+## covid people depend on things as they are for now, I'm making a
+## parallel class here.
+mcstate_trajectories_continuous <- function(time, state, predicted) {
+  if (length(predicted) == 1L) {
+    predicted <- rep_len(predicted, length(step))
+  }
+  if (any(predicted)) {
+    stop("predicted trajectories not yet supported (mrc-3452, mrc-3453)")
+  }
+  ret <- list(time = time, state = state, predicted = predicted)
+  class(ret) <- c("mcstate_trajectories_continuous", "mcstate_trajectories")
+  ret
+}
+
+
+bind_mcstate_trajectories_discrete <- function(a, b) {
+  stopifnot(inherits(a, "mcstate_trajectories_discrete"),
+            inherits(b, "mcstate_trajectories_discrete"),
             last(a$step) == b$step[[1]],
             a$rate == b$rate,
             dim(a)[1:2] == dim(b)[1:2])
@@ -25,4 +42,17 @@ bind_mcstate_trajectories <- function(a, b) {
   predicted <- c(a$predicted, b$predicted[-1])
 
   mcstate_trajectories(step, a$rate, state, predicted)
+}
+
+
+## Compatibility due to direct use in spimalot
+mcstate_trajectories <- function(...) {
+  .Deprecated("mcstate_trajectories_discrete")
+  mcstate_trajectories_discrete(...)
+}
+
+
+bind_mcstate_trajectories <- function(...) {
+  .Deprecated("bind_mcstate_trajectories")
+  bind_mcstate_trajectories_discrete(...)
 }

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -80,9 +80,17 @@ example_continuous <- function() {
                    Sh = info$index$Sh))
   }
 
+  pars <- pmcmc_parameters$new(
+    list(pmcmc_parameter("bh", 0.05, min = 0.01, max = 0.1),
+         pmcmc_parameter("bv", 0.05, min = 0.01, max = 0.1)),
+    proposal = diag(2) * 0.005)
+
+  stochastic_schedule <- seq(from = 30, by = 30, to = 1800)
+
   list(model = model, compare = compare,
        data_raw = data_raw, data = data,
-       index = index, stochastic_schedule  = seq(from = 30, by = 30, to = 1800))
+       index = index, pars = pars,
+       stochastic_schedule = stochastic_schedule)
 }
 
 

--- a/tests/testthat/malaria/malariamodel.R
+++ b/tests/testthat/malaria/malariamodel.R
@@ -46,11 +46,11 @@ initial(Iv) <- init_Iv
 # User Input #
 ##############
 init_Sh <- 1 - init_Ih
-init_Ih <- user()
-init_Sv <- user()
-init_Iv <- user()
+init_Ih <- user(0.8)
+init_Sv <- user(100)
+init_Iv <- user(1)
 
-nrates <- user()
+nrates <- user(15)
 dim(Ev) <- nrates
 
 # Ratio mosquitoes:humans

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1657,3 +1657,20 @@ test_that("Can't fetch statistics from discrete model", {
     "Statistics are only available for continuous (ODE) models",
     fixed = TRUE)
 })
+
+
+test_that("Can reconstruct a continuous time filter", {
+  dat <- example_continuous()
+  n_particles <- 42
+  ode_control <- mode::mode_control(atol = 1e-4, rtol = 1e-4)
+  p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index, seed = 1L,
+                           stochastic_schedule = dat$stochastic_schedule,
+                           ode_control = ode_control)
+  inputs <- p1$inputs()
+  expect_equal(inputs$stochastic_schedule, dat$stochastic_schedule)
+  expect_equal(inputs$ode_control, ode_control)
+
+  p2 <- particle_filter_from_inputs(inputs)
+  expect_equal(p2$inputs(), inputs)
+})

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1502,6 +1502,7 @@ test_that("run particle filter on continuous model", {
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index, seed = 1L,
                            stochastic_schedule = dat$stochastic_schedule)
+
   pars <- list(init_Ih = 0.8,
                init_Sv = 100,
                init_Iv = 1,

--- a/tests/testthat/test-pmcmc-nested.R
+++ b/tests/testthat/test-pmcmc-nested.R
@@ -368,7 +368,7 @@ test_that("run nested pmcmc with the particle filter and retain history", {
   ## Additional information required to predict
   expect_setequal(
     names(results1$predict),
-    c("transform", "index", "rate", "step", "filter"))
+    c("is_continuous", "transform", "index", "rate", "step", "time", "filter"))
 })
 
 

--- a/tests/testthat/test-pmcmc-utils.R
+++ b/tests/testthat/test-pmcmc-utils.R
@@ -152,3 +152,11 @@ test_that("deprecation warnings on old interface", {
   expect_identical(res,
                    bind_mcstate_trajectories_discrete(base, prediction))
 })
+
+
+test_that("disallow predicted in continuous trajectories", {
+  dat <- example_sir_pmcmc()$pmcmc$base
+  expect_error(
+    mcstate_trajectories_continuous(dat$step * dat$rate, dat$state, TRUE),
+    "predicted trajectories not supported")
+})

--- a/tests/testthat/test-pmcmc-utils.R
+++ b/tests/testthat/test-pmcmc-utils.R
@@ -155,8 +155,8 @@ test_that("deprecation warnings on old interface", {
 
 
 test_that("disallow predicted in continuous trajectories", {
-  dat <- example_sir_pmcmc()$pmcmc$base
+  dat <- example_sir_pmcmc()$pmcmc$trajectories
   expect_error(
     mcstate_trajectories_continuous(dat$step * dat$rate, dat$state, TRUE),
-    "predicted trajectories not supported")
+    "predicted continuous trajectories not supported")
 })

--- a/tests/testthat/test-pmcmc-utils.R
+++ b/tests/testthat/test-pmcmc-utils.R
@@ -131,3 +131,24 @@ test_that("progress bar creates progress_bar when progress = TRUE", {
     p(),
     "Finished 3 steps in [0-9.]+ secs")
 })
+
+
+test_that("deprecation warnings on old interface", {
+  results <- example_sir_pmcmc()$pmcmc
+  base <- results$trajectories
+
+  expect_warning(
+    res <- mcstate_trajectories(base$step, base$rate, base$state,
+                                base$predicted),
+    "deprecated")
+  expect_identical(res, base)
+
+  steps <- seq(results$predict$step, by = 4, length.out = 26)
+  prediction <- pmcmc_predict(results, steps, seed = 1L)
+
+  expect_warning(
+    res <- bind_mcstate_trajectories(base, prediction),
+    "deprecated")
+  expect_identical(res,
+                   bind_mcstate_trajectories_discrete(base, prediction))
+})

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -153,7 +153,7 @@ test_that("run pmcmc with the particle filter and retain history", {
   ## Additional information required to predict
   expect_setequal(
     names(results1$predict),
-    c("transform", "index", "rate", "step", "filter"))
+    c("is_continuous", "transform", "index", "rate", "step", "time", "filter"))
   expect_identical(results1$predict$transform, as.list)
   expect_equal(results1$predict$index, 1:3)
   expect_equal(results1$predict$rate, 4)

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -731,17 +731,12 @@ test_that("can run pmcmc for ode models", {
                             index = dat$index, seed = 1L,
                             stochastic_schedule = dat$stochastic_schedule)
 
-  pars <- pmcmc_parameters$new(
-    list(pmcmc_parameter("bh", 0.05, min = 0.01, max = 0.1),
-         pmcmc_parameter("bv", 0.05, min = 0.01, max = 0.1)),
-    proposal = diag(2) * 0.005)
-
   control1 <- pmcmc_control(10, save_trajectories = TRUE, save_state = TRUE)
   control2 <- pmcmc_control(10, save_trajectories = FALSE, save_state = FALSE)
   set.seed(1)
-  results1 <- pmcmc(pars, p1, control = control1)
+  results1 <- pmcmc(dat$pars, p1, control = control1)
   set.seed(1)
-  results2 <- pmcmc(pars, p2, control = control2)
+  results2 <- pmcmc(dat$pars, p2, control = control2)
 
   expect_s3_class(results1, "mcstate_pmcmc")
 

--- a/tests/testthat/test-pmcmc.R
+++ b/tests/testthat/test-pmcmc.R
@@ -767,21 +767,22 @@ test_that("can run pmcmc for ode models", {
   ## Trajectories, if returned, have the same shape
   expect_s3_class(results1$trajectories, "mcstate_trajectories")
   expect_equal(dim(results1$trajectories$state), c(2, 10, 61))
-  ## expect_equal(
-  ##   results1$trajectories$state[, , dim(results1$trajectories$state)[3]],
-  ##   results1$state[1:3, ])
+  expect_equal(
+    unname(
+      results1$trajectories$state[, , dim(results1$trajectories$state)[3]]),
+    results1$state[2:1, ])
 
-  ## TODO: some work here to do:
-  expect_equal(results1$trajectories$step, seq(0, 400, by = 4))
-  expect_equal(results1$trajectories$rate, 4)
+  expect_equal(results1$trajectories$time, seq(0, 1800, by = 30))
+  expect_null(results1$trajectories$step)
+  expect_null(results1$trajectories$rate)
 
   ## Additional information required to predict
   expect_setequal(
     names(results1$predict),
-    c("transform", "index", "rate", "step", "filter"))
+    c("is_continuous", "transform", "index", "rate", "step", "time", "filter"))
   expect_identical(results1$predict$transform, as.list)
   expect_equal(results1$predict$index, c(Ih = 2, Sh = 1))
   expect_null(results1$predict$rate)
-  ## expect_equal(results1$predict$step, last(dat$data$step_end))
+  expect_equal(results1$predict$time, last(dat$data$time_end))
   expect_identical(results1$predict$filter, p1$inputs())
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -166,3 +166,22 @@ test_that("can run a prediction from a nested mcmc run", {
 
   expect_silent(pmcmc_predict(results, steps, prepend_trajectories = TRUE))
 })
+
+
+test_that("Can't predict from a continuous pmcmc", {
+  dat <- example_continuous()
+  n_particles <- 20
+  p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                           index = dat$index, seed = 1L,
+                           stochastic_schedule = dat$stochastic_schedule)
+  pars <- pmcmc_parameters$new(
+    list(pmcmc_parameter("bh", 0.05, min = 0.01, max = 0.1),
+         pmcmc_parameter("bv", 0.05, min = 0.01, max = 0.1)),
+    proposal = diag(2) * 0.005)
+  control <- pmcmc_control(10, save_trajectories = TRUE, save_state = TRUE)
+  results <- pmcmc(pars, p, control = control)
+  expect_error(
+    pmcmc_predict(results, seq(1800, length.out = 10, by = 30)),
+    "predict not (yet) possible with continuous models (mrc-3453)",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -174,12 +174,8 @@ test_that("Can't predict from a continuous pmcmc", {
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index, seed = 1L,
                            stochastic_schedule = dat$stochastic_schedule)
-  pars <- pmcmc_parameters$new(
-    list(pmcmc_parameter("bh", 0.05, min = 0.01, max = 0.1),
-         pmcmc_parameter("bv", 0.05, min = 0.01, max = 0.1)),
-    proposal = diag(2) * 0.005)
   control <- pmcmc_control(10, save_trajectories = TRUE, save_state = TRUE)
-  results <- pmcmc(pars, p, control = control)
+  results <- pmcmc(dat$pars, p, control = control)
   expect_error(
     pmcmc_predict(results, seq(1800, length.out = 10, by = 30)),
     "predict not (yet) possible with continuous models (mrc-3453)",


### PR DESCRIPTION
Really not a lot in here because this basically works out of the box.

* trajectories makes a strong assumption about step/rate and not time; we probably need to tidy this properly later but I've put in a fix for now and 
* the prediction part also makes assumptions about step/rate and I've disabled that for now
* the helper particle_filter_from_inputs was not passing all continuous time arguments through
