### PR TITLE
Tweaks to support workers

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -27,11 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.9.10
+Version: 0.9.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),
@@ -32,7 +32,7 @@ Suggests:
     fs,
     knitr,
     mockery,
-    mode (>= 0.1.6),
+    mode (>= 0.1.9),
     mvtnorm,
     odin.dust (>= 0.2.20),
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcstate 0.9.11
+
+* Continuous time (ODE) models can now use workers for running chains in parallel with `pmcmc`
+
 # mcstate 0.9.9
 
 * Basic inference now working with continuous time (ODE) models, via `particle_filter` and `pmcmc`

--- a/R/pmcmc_parallel.R
+++ b/R/pmcmc_parallel.R
@@ -130,6 +130,11 @@ make_seeds <- function(n, seed, model) {
     n_streams <- length(seed) / 32L # 4 uint64_t, each 8 bytes
   }
 
+  ## TODO: needs a little tweak in both dust to do more nicely, but
+  ## that can wait until we merge mode into dust
+  if (inherits(model, "mode_generator")) {
+    model <- "xoshiro256plus"
+  }
   seed_dust <- dust::dust_rng_distributed_state(seed, n_streams, n, model)
 
   ## Grab another source of independent numbers to create the R

--- a/tests/testthat/test-pmcmc-parallel.R
+++ b/tests/testthat/test-pmcmc-parallel.R
@@ -208,3 +208,28 @@ test_that("Can use workers on non-package models", {
   ## failed to load the model.
   expect_s3_class(ans, "mcstate_pmcmc")
 })
+
+
+test_that("can run pmcmc for non-package ode models", {
+  dat <- example_continuous()
+  n_steps <- 5
+  n_particles <- 20
+
+  control1 <- pmcmc_control(n_steps, n_chains = 2,
+                            n_workers = 1, n_threads_total = 1,
+                            progress = FALSE, use_parallel_seed = TRUE)
+  control2 <- pmcmc_control(n_steps, n_chains = 2,
+                            n_workers = 2, n_threads_total = 2,
+                            progress = FALSE, use_parallel_seed = TRUE)
+  filter1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                                 index = dat$index, seed = 1L)
+  filter2 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
+                                 index = dat$index, seed = 1L)
+  set.seed(1)
+  ans1 <- pmcmc(dat$pars, filter1, control = control1)
+
+  set.seed(2)
+  ans2 <- pmcmc(dat$pars, filter2, control = control2)
+
+  expect_identical(ans1$pars, ans2$pars)
+})


### PR DESCRIPTION
This was really close, but the way that we handle seeding needed a slight hand. To avoid some confusing errors, we also need to depend on the most recent copy of mode.

In the meantime, it looks like the `master` branch has gone on the actions that we use, so I've updated these to point at `v1` which we use elsewhere