### PR TITLE
Return and use all inputs in filter construction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Suggests:
     fs,
     knitr,
     mockery,
-    mode (>= 0.1.9),
+    mode (>= 0.1.12),
     mvtnorm,
     odin.dust (>= 0.2.20),
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.9.13
+Version: 0.9.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/deterministic.R
+++ b/R/deterministic.R
@@ -313,6 +313,11 @@ particle_deterministic <- R6::R6Class(
     ##' filter. These correspond directly to the argument names for the
     ##' constructor and are the same as the input arguments.
     inputs = function() {
+      if (self$has_multiple_parameters) {
+        n_parameters <- self$n_parameters
+      } else {
+        n_parameters <- NULL
+      }
       list(data = private$data,
            model = self$model,
            index = private$index,
@@ -320,7 +325,7 @@ particle_deterministic <- R6::R6Class(
            compare = private$compare,
            constant_log_likelihood = private$constant_log_likelihood,
            n_threads = private$n_threads,
-           seed = filter_current_seed(last(private$last_model), NULL))
+           n_parameters = n_parameters)
     },
 
     ##' @description

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -546,30 +546,50 @@ particle_resample <- function(weights) {
 ## `$inputs()` data, but possibly changing the seed
 particle_filter_from_inputs <- function(inputs, seed = NULL) {
   if (is.null(inputs$n_particles)) {
-    particle_deterministic$new(
-      data = inputs$data,
-      model = inputs$model,
-      compare = inputs$compare,
-      index = inputs$index,
-      initial = inputs$initial,
-      constant_log_likelihood = inputs$constant_log_likelihood,
-      n_threads = inputs$n_threads)
+    particle_filter_from_inputs_deterministic(inputs)
   } else {
-    particle_filter$new(
-      data = inputs$data,
-      model = inputs$model,
-      n_particles = inputs$n_particles,
-      compare = inputs$compare,
-      gpu_config = inputs$gpu_config,
-      index = inputs$index,
-      initial = inputs$initial,
-      constant_log_likelihood = inputs$constant_log_likelihood,
-      n_threads = inputs$n_threads,
-      seed = seed %||% inputs$seed,
-      stochastic_schedule = inputs$stochastic_schedule,
-      ode_control = inputs$ode_control)
+    particle_filter_from_inputs_stochastic(inputs, seed)
   }
 }
+
+
+particle_filter_from_inputs_deterministic <- function(inputs) {
+  particle_deterministic$new(
+    data = inputs$data,
+    model = inputs$model,
+    compare = inputs$compare,
+    index = inputs$index,
+    initial = inputs$initial,
+    constant_log_likelihood = inputs$constant_log_likelihood,
+    n_threads = inputs$n_threads,
+    n_parameters = inputs$n_parameters)
+}
+
+
+particle_filter_from_inputs_stochastic <- function(inputs, seed) {
+  particle_filter$new(
+    data = inputs$data,
+    model = inputs$model,
+    n_particles = inputs$n_particles,
+    compare = inputs$compare,
+    gpu_config = inputs$gpu_config,
+    index = inputs$index,
+    initial = inputs$initial,
+    constant_log_likelihood = inputs$constant_log_likelihood,
+    n_threads = inputs$n_threads,
+    n_parameters = n_parameters,
+    seed = seed %||% inputs$seed,
+    stochastic_schedule = inputs$stochastic_schedule,
+    ode_control = inputs$ode_control)
+}
+
+check_inputs <- function(inputs, class) {
+  args <- formals(class$public_methods$initialize)
+  if (!setequal(names(inputs), names(args))) {
+    stop("inputs incompatible with this mcstate version")
+  }
+}
+
 
 
 scale_log_weights <- function(log_weights) {

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -583,14 +583,6 @@ particle_filter_from_inputs_stochastic <- function(inputs, seed) {
     ode_control = inputs$ode_control)
 }
 
-check_inputs <- function(inputs, class) {
-  args <- formals(class$public_methods$initialize)
-  if (!setequal(names(inputs), names(args))) {
-    stop("inputs incompatible with this mcstate version")
-  }
-}
-
-
 
 scale_log_weights <- function(log_weights) {
   log_weights[is.nan(log_weights)] <- -Inf

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -577,7 +577,7 @@ particle_filter_from_inputs_stochastic <- function(inputs, seed) {
     initial = inputs$initial,
     constant_log_likelihood = inputs$constant_log_likelihood,
     n_threads = inputs$n_threads,
-    n_parameters = n_parameters,
+    n_parameters = inputs$n_parameters,
     seed = seed %||% inputs$seed,
     stochastic_schedule = inputs$stochastic_schedule,
     ode_control = inputs$ode_control)

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -436,7 +436,7 @@ particle_filter <- R6::R6Class(
     ##' calling through to the `$statistics()` method of the underlying
     ##' model. This is only available for continuous time (ODE) models,
     ##' and will error if used with discrete time models.
-    statistics = function() {
+    ode_statistics = function() {
       if (!inherits(private$data, "particle_filter_data_continuous")) {
         stop("Statistics are only available for continuous (ODE) models")
       }
@@ -445,7 +445,7 @@ particle_filter <- R6::R6Class(
       }
       ## when/if we support multistage models, more care will be
       ## needed here.
-      private$last_model[[1]]$statistics()
+      private$last_model[[1]]$ode_statistics()
     },
 
     ##' @description

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -230,7 +230,7 @@ particle_filter_state <- R6::R6Class(
                                  n_particles = n_particles,
                                  n_threads = n_threads,
                                  seed = seed,
-                                 control = ode_control)
+                                 ode_control = ode_control)
           model$set_stochastic_schedule(stochastic_schedule)
         } else {
           model <- generator$new(pars = pars, time = times[[1L]],

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -274,7 +274,9 @@ test_that("can return inputs, and these are the full interface", {
   expect_setequal(names(inputs), names(formals(p$initialize)))
 
   ## Can't use mockery to spy on the calls, so check that all args are
-  ## used statically instead
+  ## used statically instead; and this trick does not work with the
+  ## way that covr works!
+  testthat::skip_on_covr()
   exprs <- body(particle_filter_from_inputs_deterministic)
   args <- names(as.list(exprs[[2]][-1]))
   expect_setequal(args, names(inputs))

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -267,6 +267,20 @@ test_that("Can reference by name in compare", {
 })
 
 
+test_that("can return inputs, and these are the full interface", {
+  dat <- example_sir()
+  p <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
+  inputs <- p$inputs()
+  expect_setequal(names(inputs), names(formals(p$initialize)))
+
+  ## Can't use mockery to spy on the calls, so check that all args are
+  ## used statically instead
+  exprs <- body(particle_filter_from_inputs_deterministic)
+  args <- names(as.list(exprs[[2]][-1]))
+  expect_setequal(args, names(inputs))
+})
+
+
 test_that("reconstruct deterministic filter from inputs", {
   dat <- example_sir()
   p1 <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1639,10 +1639,10 @@ test_that("Can fetch statistics from continuous model", {
                init_Sv = 100,
                init_Iv = 1,
                nrates = 15)
-  expect_error(p$statistics(),
+  expect_error(p$ode_statistics(),
                "Model has not yet been run")
   res <- p$run(pars)
-  s <- p$statistics()
+  s <- p$ode_statistics()
   expect_s3_class(s, "mode_statistics")
 })
 
@@ -1654,12 +1654,12 @@ test_that("Can't fetch statistics from discrete model", {
   p <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index, seed = 1L)
   expect_error(
-    p$statistics(),
+    p$ode_statistics(),
     "Statistics are only available for continuous (ODE) models",
     fixed = TRUE)
   res <- p$run()
   expect_error(
-    p$statistics(),
+    p$ode_statistics(),
     "Statistics are only available for continuous (ODE) models",
     fixed = TRUE)
 })

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -334,6 +334,12 @@ test_that("can return inputs", {
   inputs <- p$inputs()
   expect_setequal(names(inputs), names(formals(p$initialize)))
 
+  ## Can't use mockery to spy on the calls, so check that all args are
+  ## used statically instead
+  exprs <- body(particle_filter_from_inputs_stochastic)
+  args <- names(as.list(exprs[[2]][-1]))
+  expect_setequal(args, names(inputs))
+
   expect_equal(inputs$data, dat$data)
   expect_equal(inputs$model, dat$model)
   expect_equal(inputs$n_particles, n_particles)

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -334,12 +334,6 @@ test_that("can return inputs", {
   inputs <- p$inputs()
   expect_setequal(names(inputs), names(formals(p$initialize)))
 
-  ## Can't use mockery to spy on the calls, so check that all args are
-  ## used statically instead
-  exprs <- body(particle_filter_from_inputs_stochastic)
-  args <- names(as.list(exprs[[2]][-1]))
-  expect_setequal(args, names(inputs))
-
   expect_equal(inputs$data, dat$data)
   expect_equal(inputs$model, dat$model)
   expect_equal(inputs$n_particles, n_particles)
@@ -359,6 +353,14 @@ test_that("can return inputs", {
 
   expect_identical(inputs2[names(inputs2) != "seed"],
                    inputs[names(inputs) != "seed"])
+
+  ## Can't use mockery to spy on the calls, so check that all args are
+  ## used statically instead; and this trick does not work with the
+  ## way that covr works!
+  testthat::skip_on_covr()
+  exprs <- body(particle_filter_from_inputs_stochastic)
+  args <- names(as.list(exprs[[2]][-1]))
+  expect_setequal(args, names(inputs))
 })
 
 


### PR DESCRIPTION
Small issue noticed setting something up for @MJomaba; the n_particles arg is not passed around properly when we get the inputs from a filter, or reconstruct a filter from inputs.

This PR fixes this but also adds a little test to check

* that the deterministic `inputs()` fully matches the constructor (this was already done for the particle filter)
* that all inputs are passed as inputs to the constructor; this can't be done with mockery as it can't mock R6 constructors, so it's done statically which required splitting apart `particle_filter_from_inputs` - that trick does not work with covr due to the way that covr instruments the R calls

There's also a couple of tiny tweaks due to changes in mode recently - moving `statistics()` to `ode_statistics()` and `control` to `ode_control`