### PR TITLE
Remove mode workarounds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     rmarkdown,
     testthat,
     withr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Remotes:
     mrc-ide/dust@mrc-4055,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Suggests:
     knitr,
     mockery,
     mvtnorm,
-    odin.dust (>= 0.2.20),
+    odin.dust (>= 0.3.0),
     rmarkdown,
     testthat,
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,6 @@ Suggests:
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Remotes:
-    mrc-ide/dust@mrc-4055,
+    mrc-ide/dust,
     mrc-ide/odin.dust
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.9.14
+Version: 0.9.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),
@@ -22,7 +22,7 @@ BugReports: https://github.com/mrc-ide/mcstate/issues
 Imports:
     R6,
     callr (>= 3.7.0),
-    dust (>= 0.11.28),
+    dust (>= 0.13.12),
     processx,
     progress (>= 1.2.0)
 Suggests:
@@ -32,7 +32,6 @@ Suggests:
     fs,
     knitr,
     mockery,
-    mode (>= 0.1.12),
     mvtnorm,
     odin.dust (>= 0.2.20),
     rmarkdown,
@@ -41,6 +40,6 @@ Suggests:
 RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 Remotes:
-    mrc-ide/dust,
+    mrc-ide/dust@mrc-4055,
     mrc-ide/odin.dust
 VignetteBuilder: knitr

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -269,7 +269,7 @@ particle_filter <- R6::R6Class(
                      "support this"))
         }
       } else {
-        assert_is_or_null(ode_control, "mode_control")
+        assert_is_or_null(ode_control, "dust_ode_control")
         private$stochastic_schedule <- stochastic_schedule
         private$ode_control <- ode_control
       }

--- a/R/particle_filter.R
+++ b/R/particle_filter.R
@@ -253,10 +253,10 @@ particle_filter <- R6::R6Class(
       data_is_continuous <- inherits(data, "particle_filter_data_continuous")
       has_multiple_data <- inherits(data, "particle_filter_data_nested")
 
-      model_is_continuous <- model$public_methods$data_type() == "continuous"
-      if (model_is_continuous != is_continuous) {
+      model_is_continuous <- model$public_methods$time_type() == "continuous"
+      if (model_is_continuous != data_is_continuous) {
         stop(sprintf("'model' is %s but 'data' is of type '%s'",
-                     model$public_methods$data_type(), class(data)[2]))
+                     model$public_methods$time_type(), class(data)[2]))
       }
 
       if (!model_is_continuous) {

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -230,7 +230,8 @@ particle_filter_state <- R6::R6Class(
                                  n_particles = n_particles,
                                  n_threads = n_threads,
                                  seed = seed,
-                                 ode_control = ode_control)
+                                 ode_control = ode_control,
+                                 pars_multi = has_multiple_parameters)
           model$set_stochastic_schedule(stochastic_schedule)
         } else {
           model <- generator$new(pars = pars, time = times[[1L]],

--- a/R/particle_filter_state.R
+++ b/R/particle_filter_state.R
@@ -265,11 +265,7 @@ particle_filter_state <- R6::R6Class(
       }
 
       ## The model shape is [n_particles, <any multi-par structure>]
-      if (is_continuous) {
-        shape <- model$n_particles()
-      } else {
-        shape <- model$shape()
-      }
+      shape <- model$shape()
 
       if (save_history) {
         len <- nrow(times) + 1L

--- a/R/pmcmc_parallel.R
+++ b/R/pmcmc_parallel.R
@@ -130,11 +130,6 @@ make_seeds <- function(n, seed, model) {
     n_streams <- length(seed) / 32L # 4 uint64_t, each 8 bytes
   }
 
-  ## TODO: needs a little tweak in both dust to do more nicely, but
-  ## that can wait until we merge mode into dust
-  if (inherits(model, "mode_generator")) {
-    model <- "xoshiro256plus"
-  }
   seed_dust <- dust::dust_rng_distributed_state(seed, n_streams, n, model)
 
   ## Grab another source of independent numbers to create the R

--- a/man/if2.Rd
+++ b/man/if2.Rd
@@ -65,7 +65,7 @@ for (i in day) {
 
 # Convert this into our required format:
 data_raw <- data.frame(day = day, incidence = incidence)
-data <- particle_filter_data(data_raw, "day", 4)
+data <- particle_filter_data(data_raw, "day", 4, 0)
 
 # A comparison function
 compare <- function(state, observed, pars = NULL) {

--- a/man/particle_deterministic.Rd
+++ b/man/particle_deterministic.Rd
@@ -63,7 +63,9 @@ Create the particle filter
   initial = NULL,
   constant_log_likelihood = NULL,
   n_threads = 1L,
-  n_parameters = NULL
+  n_parameters = NULL,
+  stochastic_schedule = NULL,
+  ode_control = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -119,7 +121,8 @@ constructor, i.e., not less than the first element of
 \code{time_start} and not more than \code{time_end}). Your function
 can also return a vector or matrix of \code{state} and not alter
 the starting time, which is equivalent to returning
-\code{list(state = state, time = NULL)}. (TODO: this no longer is allowed, and the docs might be out of date?)}
+\code{list(state = state, time = NULL)}.
+(TODO: this no longer is allowed, and the docs might be out of date?)}
 
 \item{\code{constant_log_likelihood}}{An optional function, taking the
 model parameters, that computes the constant part of the
@@ -141,6 +144,14 @@ particle for now.}
 with \code{data}, controls the interpretation of how the deterministic
 particle, and importantly will add an additional dimension to
 most outputs (scalars become vectors, vectors become matrices etc).}
+
+\item{\code{stochastic_schedule}}{Vector of times to perform stochastic
+updates, for continuous time models. Note that despite the name,
+these will be applied deterministically (i.e., replacing the
+stochastic draw with its expectation).}
+
+\item{\code{ode_control}}{Tuning control for the ODE stepper, for
+continuous time (ODE) models}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/particle_deterministic_state.Rd
+++ b/man/particle_deterministic_state.Rd
@@ -64,7 +64,9 @@ documented.
   compare,
   constant_log_likelihood,
   save_history,
-  save_restart
+  save_restart,
+  stochastic_schedule,
+  ode_control
 )}\if{html}{\out{</div>}}
 }
 
@@ -98,6 +100,10 @@ documented.
 \item{\code{save_history}}{Logical, indicating if we should save history}
 
 \item{\code{save_restart}}{Vector of time steps to save restart at}
+
+\item{\code{stochastic_schedule}}{Vector of times to perform stochastic updates}
+
+\item{\code{ode_control}}{Tuning control for stepper}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -30,7 +30,7 @@ for (i in day) {
 
 # Convert this into our required format:
 data_raw <- data.frame(day = day, incidence = incidence)
-data <- particle_filter_data(data_raw, "day", 4)
+data <- particle_filter_data(data_raw, "day", 4, 0)
 
 # A comparison function
 compare <- function(state, observed, pars = NULL) {
@@ -98,7 +98,7 @@ this will be 1.}
 \item \href{#method-particle_filter-run_begin}{\code{particle_filter$run_begin()}}
 \item \href{#method-particle_filter-state}{\code{particle_filter$state()}}
 \item \href{#method-particle_filter-history}{\code{particle_filter$history()}}
-\item \href{#method-particle_filter-statistics}{\code{particle_filter$statistics()}}
+\item \href{#method-particle_filter-ode_statistics}{\code{particle_filter$ode_statistics()}}
 \item \href{#method-particle_filter-restart_state}{\code{particle_filter$restart_state()}}
 \item \href{#method-particle_filter-inputs}{\code{particle_filter$inputs()}}
 \item \href{#method-particle_filter-set_n_threads}{\code{particle_filter$set_n_threads()}}
@@ -382,15 +382,15 @@ histories.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-particle_filter-statistics"></a>}}
-\if{latex}{\out{\hypertarget{method-particle_filter-statistics}{}}}
-\subsection{Method \code{statistics()}}{
+\if{html}{\out{<a id="method-particle_filter-ode_statistics"></a>}}
+\if{latex}{\out{\hypertarget{method-particle_filter-ode_statistics}{}}}
+\subsection{Method \code{ode_statistics()}}{
 Fetch statistics about steps taken during the integration, by
 calling through to the \verb{$statistics()} method of the underlying
 model. This is only available for continuous time (ODE) models,
 and will error if used with discrete time models.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{particle_filter$statistics()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{particle_filter$ode_statistics()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/particle_filter_data.Rd
+++ b/man/particle_filter_data.Rd
@@ -19,13 +19,15 @@ each time point (in model time \code{time}).  This must also be
 integer-like for discrete time models and must be \code{NULL} for
 continuous time models.}
 
-\item{initial_time}{Optionally, an initial time to start the model
-from.  Provide this if you need to burn the model in, or if
-there is a long period with no data at the beginning of the
-simulation.  If provided, it must be a non-negative integer and
-must be at most equal to the first value of the \code{time} column,
-minus 1 (i.e., \code{data[[time]] - 1}). For discrete time models,
-this is expressed in model time.}
+\item{initial_time}{An initial time to start the model from. This
+should always be provided, and must be provided for continuous
+time models. For discrete time models, this is expressed in
+model time. It must be a non-negative integer and must be at
+most equal to the first value of the \code{time} column, minus 1
+(i.e., \code{data[[time]] - 1}). For historical reasons if not given
+we take the first value of the \code{time} column minus one, but with
+a warning - this behaviour will be removed in a future version
+of mcstate.}
 
 \item{population}{Optionally, the name of a column within \code{data} that
 represents different populations. Must be a factor.}
@@ -68,11 +70,11 @@ at step 10, day 15 at step 150 and so on.
 }
 \examples{
 d <- data.frame(day = 5:20, y = runif(16))
-mcstate::particle_filter_data(d, "day", 4)
+mcstate::particle_filter_data(d, "day", rate = 4, initial_time = 4)
 
 # If providing an initial day, then the first epoch of simulation
 # will be longer (see the first row)
-mcstate::particle_filter_data(d, "day", 4, 0)
+mcstate::particle_filter_data(d, "day", rate = 4, initial_time = 0)
 
 # If including populations:
 d <- data.frame(day = 5:20, y = runif(16),

--- a/man/smc2.Rd
+++ b/man/smc2.Rd
@@ -54,7 +54,7 @@ sir <- dust::dust_example("sir")
 incidence <- read.csv(system.file("sir_incidence.csv", package = "mcstate"))
 
 # Annotate the data so that it is suitable for the particle filter to use
-dat <- mcstate::particle_filter_data(incidence, "day", 4)
+dat <- mcstate::particle_filter_data(incidence, "day", 4, 0)
 
 # Subset the output during run
 index <- function(info) {

--- a/tests/testthat/helper-mcstate.R
+++ b/tests/testthat/helper-mcstate.R
@@ -61,6 +61,7 @@ example_sir <- function() {
 }
 
 example_continuous <- function() {
+  skip_if_not_installed("odin.dust")
   model <- odin.dust::odin_dust("malaria/malariamodel.R", verbose = FALSE)
 
   compare <- function(state, observed, pars = NULL) {
@@ -474,6 +475,7 @@ random_array <- function(dim, named = FALSE) {
 
 
 example_variable <- function() {
+  testthat::skip_if_not_installed("odin.dust")
   ## A small, very silly, model designed to help work with the
   ## multistage filter.  We have a model we can change the dimensions of
   ## without changing the way that the random number draws will work

--- a/tests/testthat/test-deterministic.R
+++ b/tests/testthat/test-deterministic.R
@@ -457,3 +457,13 @@ test_that("Can run an adaptive proposal, increasing acceptance rate", {
   expect_lt(coda::rejectionRate(coda::mcmc(res1$pars))[[1]],
             coda::rejectionRate(coda::mcmc(res2$pars))[[1]])
 })
+
+
+test_that("Can run the deterministic filter on ODE model", {
+  dat <- example_continuous()
+
+  p <- particle_deterministic$new(dat$data, dat$model, dat$compare, dat$index)
+  set.seed(1)
+  ll <- p$run(dat$pars$model(dat$pars$initial()))
+  expect_equal(ll, -62466.04)
+})

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1570,7 +1570,7 @@ test_that("can provide ode_control for continuous model", {
 })
 
 
-test_that("ovide ode_control must be of type mode_control", {
+test_that("if provided, ode_control must be of type dust_ode_control", {
   dat <- example_continuous()
   pars <- list(init_Ih = 0.8,
                init_Sv = 100,
@@ -1578,7 +1578,7 @@ test_that("ovide ode_control must be of type mode_control", {
                nrates = 15)
   expect_error(particle_filter$new(dat$data, dat$model, 1, dat$compare,
                                    index = dat$index, ode_control = c(1, 2, 3)),
-               "'ode_control' must be a mode_control")
+               "'ode_control' must be a dust_ode_control")
 })
 
 
@@ -1645,7 +1645,7 @@ test_that("Can fetch statistics from continuous model", {
                "Model has not yet been run")
   res <- p$run(pars)
   s <- p$ode_statistics()
-  expect_s3_class(s, "mode_statistics")
+  expect_s3_class(s, "ode_statistics")
 })
 
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1591,19 +1591,30 @@ test_that("cannot provide ode_control for discrete model", {
 })
 
 
-test_that("cannot provide nested data for continuous model", {
+test_that("Can run nested filter for continuous model", {
   dat <- example_continuous()
   data_raw <- read.csv("malaria/casedata_monthly.csv",
                        stringsAsFactors = FALSE)
+  np <- 100
+  data1 <- particle_filter_data(data_raw, time = "day", initial_time = 0,
+                                rate = NULL)
+  f1 <- particle_filter$new(data1, dat$model, np, dat$compare,
+                            index = dat$index, seed = 1L)
+
   data_raw$population <- as.factor("A")
-  data <- particle_filter_data(data_raw, time = "day", initial_time = 0,
-                               rate = NULL, population = "population")
-  expect_error(particle_filter$new(data,
-                           dat$model,
-                           1,
-                           dat$compare,
-                           index = dat$index),
-               "nested data not supported for continuous models")
+  data2 <- particle_filter_data(data_raw, time = "day", initial_time = 0,
+                                rate = NULL, population = "population")
+  f2 <- particle_filter$new(data2, dat$model, np, dat$compare,
+                            index = dat$index, seed = 1L)
+
+  p <- dat$pars$model(dat$pars$initial())
+
+  set.seed(1)
+  ll1 <- f1$run(p)
+
+  set.seed(1)
+  ll2 <- f2$run(list(p))
+  expect_identical(ll1, ll2)
 })
 
 

--- a/tests/testthat/test-particle-filter.R
+++ b/tests/testthat/test-particle-filter.R
@@ -1562,7 +1562,7 @@ test_that("can provide ode_control for continuous model", {
                init_Sv = 100,
                init_Iv = 1,
                nrates = 15)
-  ctl <- mode::mode_control(max_steps = 1, atol = 1e-2, rtol = 1e-2)
+  ctl <- dust::dust_ode_control(max_steps = 1, atol = 1e-2, rtol = 1e-2)
   p <- particle_filter$new(dat$data, dat$model, 1, dat$compare,
                            index = dat$index, seed = 1L,
                            ode_control = ctl)
@@ -1584,7 +1584,7 @@ test_that("ovide ode_control must be of type mode_control", {
 
 test_that("cannot provide ode_control for discrete model", {
   dat <- example_sir()
-  ctl <- mode::mode_control(max_steps = 100000, atol = 1e-2, rtol = 1e-2)
+  ctl <- dust::dust_ode_control(max_steps = 100000, atol = 1e-2, rtol = 1e-2)
   expect_error(particle_filter$new(dat$data, dat$model, 1, dat$compare,
                                    index = dat$index, ode_control = ctl),
                "'ode_control' provided but 'model' does not support this")
@@ -1670,7 +1670,7 @@ test_that("Can't fetch statistics from discrete model", {
 test_that("Can reconstruct a continuous time filter", {
   dat <- example_continuous()
   n_particles <- 42
-  ode_control <- mode::mode_control(atol = 1e-4, rtol = 1e-4)
+  ode_control <- dust::dust_ode_control(atol = 1e-4, rtol = 1e-4)
   p1 <- particle_filter$new(dat$data, dat$model, n_particles, dat$compare,
                            index = dat$index, seed = 1L,
                            stochastic_schedule = dat$stochastic_schedule,


### PR DESCRIPTION
This PR harmonises the interface to use continuous time models from dust, rather than mode.

Depends on https://github.com/mrc-ide/dust/pull/398 as that introduces the method for detecting if a dust model is continuous time or discrete time