### PR TITLE
Split fixed priors across populations for nested models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.9.18
+Version: 0.9.19
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/pmcmc_parameters_nested.R
+++ b/R/pmcmc_parameters_nested.R
@@ -215,7 +215,7 @@ pmcmc_parameters_nested <- R6::R6Class(
 
       nms_fixed <- self$names("fixed")
       if (length(nms_fixed) > 0) {
-        ret <- ret + 
+        ret <- ret +
           private$inner$fixed$prior(theta[nms_fixed, 1]) / length(pops)
       }
 

--- a/R/pmcmc_parameters_nested.R
+++ b/R/pmcmc_parameters_nested.R
@@ -215,7 +215,8 @@ pmcmc_parameters_nested <- R6::R6Class(
 
       nms_fixed <- self$names("fixed")
       if (length(nms_fixed) > 0) {
-        ret <- ret + private$inner$fixed$prior(theta[nms_fixed, 1])
+        ret <- ret + 
+          private$inner$fixed$prior(theta[nms_fixed, 1]) / length(pops)
       }
 
       nms_varied <- self$names("varied")

--- a/tests/testthat/test-pmcmc-parameters-nested.R
+++ b/tests/testthat/test-pmcmc-parameters-nested.R
@@ -297,7 +297,7 @@ test_that("pmcmc_parameters_nested prior", {
   p <- pmcmc_parameters_nested$new(parameters, proposal_varied, proposal_fixed)
 
   init <- p$initial()
-  expect_equal(p$prior(init), set_names(c(15, 17), c("p1", "p2")))
+  expect_equal(p$prior(init), set_names(c(9.5, 11.5), c("p1", "p2")))
 
   parameters <- list(
     a = pmcmc_varied_parameter("a", c("p1", "p2"), 1:2,
@@ -311,7 +311,8 @@ test_that("pmcmc_parameters_nested prior", {
 
   init <- p$initial()
   expect_equal(p$prior(init),
-               set_names(c(11 + dnorm(1) + dlnorm(3), 11 + dexp(2) + dlnorm(4)),
+               set_names(c(5.5 + dnorm(1) + dlnorm(3),
+                           5.5 + dexp(2) + dlnorm(4)),
                          c("p1", "p2")))
 })
 


### PR DESCRIPTION
This fixes a bug in the nested pmcmc where priors for fixed parameters were counted in each population when they need to be only counted once. The quick fix is to simply divide the fixed prior by the number of populations.