### PR TITLE
Fix adaptive nested

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate
 Title: Monte Carlo Methods for State Space Models
-Version: 0.9.21
+Version: 0.9.22
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Marc", "Baguelin", role = "aut"),

--- a/R/adaptive_proposal.R
+++ b/R/adaptive_proposal.R
@@ -324,8 +324,7 @@ adaptive_proposal_nested <- R6::R6Class(
           theta_remove <- lapply(seq_len(ncol(theta_remove)), function(j)
             theta_remove[idx, j, drop = TRUE])
         }
-        self$included[[type]] <-
-          c(self$included[[type]][-1L], i)
+        self$included[[type]] <- c(self$included[[type]][-1L], i)
       } else {
         if (type == "fixed") {
           theta_remove <- NULL

--- a/R/adaptive_proposal.R
+++ b/R/adaptive_proposal.R
@@ -325,15 +325,14 @@ adaptive_proposal_nested <- R6::R6Class(
             theta_remove[idx, j, drop = TRUE])
         }
         self$included[[type]] <-
-          c(self$included[[type]][-1L], self$iteration[[type]])
+          c(self$included[[type]][-1L], i)
       } else {
         if (type == "fixed") {
           theta_remove <- NULL
         } else {
           theta_remove <- rep(list(NULL), length(theta_type))
         }
-        self$included[[type]] <- 
-          c(self$included[[type]], self$iteration[[type]])
+        self$included[[type]] <- c(self$included[[type]], i)
         self$weight[[type]] <- self$weight[[type]] + 1
       }
       

--- a/tests/testthat/test-deterministic-nested.R
+++ b/tests/testthat/test-deterministic-nested.R
@@ -119,6 +119,22 @@ test_that("Can run a nested adaptive proposal, increasing acceptance rate", {
   expect_setequal(names(res1$adaptive$weight), c("fixed", "varied"))
   expect_null(res2$adaptive)
   
+  i_fixed <- seq(17, 80, by = 2)
+  i_varied <- i_fixed + 1
+  
+  expect_equivalent(res1$adaptive$mean$fixed,
+                    mean(res1$pars[i_fixed, "gamma", "a"]))
+  expect_equivalent(res1$adaptive$vcv$fixed,
+                    var(res1$pars[i_fixed, "gamma", "a"]))
+  expect_equivalent(res1$adaptive$mean$varied$a,
+                    mean(res1$pars[i_varied, "beta", "a"]))
+  expect_equivalent(res1$adaptive$vcv$varied$a,
+                    var(res1$pars[i_varied, "beta", "a"]))
+  expect_equivalent(res1$adaptive$mean$varied$b,
+                    mean(res1$pars[i_varied, "beta", "b"]))
+  expect_equivalent(res1$adaptive$vcv$varied$b,
+                    var(res1$pars[i_varied, "beta", "b"]))
+  
   combined <- pmcmc_combine(samples = rep(list(res1), 3))
   expect_equal(dim(combined$adaptive$autocorrelation$fixed), c(1, 1, 3)) 
   expect_equal(dim(combined$adaptive$autocorrelation$varied$a), c(1, 1, 3))
@@ -134,4 +150,6 @@ test_that("Can run a nested adaptive proposal, increasing acceptance rate", {
   expect_equal(dim(combined$adaptive$vcv$varied$b), c(1, 1, 3))
   expect_equal(length(combined$adaptive$weight$fixed), 3)
   expect_equal(length(combined$adaptive$weight$varied), 3)
+  
+  
 })

--- a/tests/testthat/test-deterministic-nested.R
+++ b/tests/testthat/test-deterministic-nested.R
@@ -150,6 +150,4 @@ test_that("Can run a nested adaptive proposal, increasing acceptance rate", {
   expect_equal(dim(combined$adaptive$vcv$varied$b), c(1, 1, 3))
   expect_equal(length(combined$adaptive$weight$fixed), 3)
   expect_equal(length(combined$adaptive$weight$varied), 3)
-  
-  
 })


### PR DESCRIPTION
This fixes an issue with the nested adaptive (impacting only that algorithm, and the fix impacts only that), which arose when I refactored it to more closely resemble the mcstate2 version. The `included` vector ended up being wrong, and as a result it would start removing parameter sets that had already been removed from the VCV, ultimately resulting in it not being positive definite. I added testing to check this fix is updating the VCV correctly now.

No fix needed in the mcstate2 PR (where we were already testing that the VCV is calculated correctly), as the issue only arose here as we were doing fixed/varied updates at alternating steps.